### PR TITLE
Improve button width and file size display

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -13,7 +13,8 @@ import {
   getQuotaInfo, 
   setQuotaInfo, 
   updateQuotaStatus,
-  fixDownloadButtonDisplay
+  fixDownloadButtonDisplay,
+  formatFileSize
 } from './utils.js';
 
 import { 
@@ -260,10 +261,9 @@ export async function processImages(files, maxW, maxH, quality, format) {
       // Update table with file size
       const sizeCell = document.querySelector(`#preview-tbody tr:nth-child(${i+1}) .size-cell`);
       if (sizeCell) {
-        const size = (blob.size / 1024).toFixed(1);
-        const originalSize = (file.size / 1024).toFixed(1);
+        const size = formatFileSize(blob.size);
         const reduction = (100 - (blob.size / file.size * 100)).toFixed(1);
-        sizeCell.innerHTML = `${size} KB<br><span style="color:#7fd7c4;font-size:0.85em;">${reduction}% smaller</span>`;
+        sizeCell.innerHTML = `${size}<br><span style="color:#7fd7c4;font-size:0.85em;">${reduction}% smaller</span>`;
       }
       
       // Enable download button

--- a/core.js
+++ b/core.js
@@ -13,7 +13,8 @@ import {
   checkHeicSupport, 
   checkWasmSupport,
   toggleStripeAccordion,
-  initImageProcessingLibraries
+  initImageProcessingLibraries,
+  formatFileSize
 } from './utils.js';
 
 import { 
@@ -360,9 +361,9 @@ async function processSingleImage(index) {
     
     // Update file size display
     if (sizeCell) {
-      const size = (blob.size / 1024).toFixed(1);
+      const size = formatFileSize(blob.size);
       const reduction = (100 - (blob.size / file.size * 100)).toFixed(1);
-      sizeCell.innerHTML = `${size} KB<br><span style="color:#7fd7c4;font-size:0.85em;">${reduction}% smaller</span>`;
+      sizeCell.innerHTML = `${size}<br><span style="color:#7fd7c4;font-size:0.85em;">${reduction}% smaller</span>`;
     }
     
     // Enable download button

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Image to WebP Converter</title>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,7 @@ label, th, .font-medium, .text-blue-900, .text-gray-500, .text-lg, .text-sm, .te
   background-color: #cde5da !important;
   color: #172f37 !important;
   border: 2px solid #cde5da !important;
+  white-space: nowrap;
 }
 
 #download-link:hover, #download-selected:hover {
@@ -292,7 +293,7 @@ img.preview { max-width: clamp(80px, 10vw, 120px); max-height: clamp(80px, 10vw,
   margin-bottom: 1.5rem;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .download-btns-responsive {
     flex-direction: column;
     gap: 0.5rem;
@@ -301,6 +302,7 @@ img.preview { max-width: clamp(80px, 10vw, 120px); max-height: clamp(80px, 10vw,
   #download-link, #download-selected {
     min-width: unset;
     width: 100%;
+    max-width: 250px;
   }
 }
 

--- a/utils.js
+++ b/utils.js
@@ -132,6 +132,15 @@ export function canProcessImages(num, files) {
   return Math.min(valid, 100 - quota.used);
 }
 
+// Format file size in KB or MB for readability
+export function formatFileSize(bytes) {
+  const kb = bytes / 1024;
+  if (kb >= 1024) {
+    return `${(kb / 1024).toFixed(1)} MB`;
+  }
+  return `${kb.toFixed(1)} KB`;
+}
+
 // Format detectors
 export function isAvif(file) {
   return file.type === 'image/avif' || file.name.toLowerCase().endsWith('.avif');


### PR DESCRIPTION
## Summary
- make download buttons match the Select Images button width on small screens
- prevent button text wrapping
- show output sizes in MB when appropriate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cca8893088333b6efb145321ccb9c