### PR TITLE
Add resolution presets and vertical ratio toggle

### DIFF
--- a/core.js
+++ b/core.js
@@ -41,6 +41,8 @@ let maxWidthInput;
 let maxHeightInput;
 let qualityInput;
 let outputFormatInput;
+let resolutionPreset;
+let verticalRatioToggle;
 let progressStatus;
 let progressBar;
 let convertImagesBtn;
@@ -1174,6 +1176,31 @@ function setupEventListeners() {
       }
     });
   }
+
+  // Resolution preset handling
+  if (resolutionPreset) {
+    resolutionPreset.addEventListener('change', () => {
+      const val = resolutionPreset.value;
+      if (val) {
+        const [w, h] = val.split('x').map(n => parseInt(n, 10));
+        if (!isNaN(w)) maxWidthInput.value = w;
+        if (!isNaN(h)) maxHeightInput.value = h;
+      }
+    });
+  }
+
+  // Vertical 2:1 toggle
+  if (verticalRatioToggle) {
+    const updateVerticalRatio = () => {
+      if (verticalRatioToggle.checked) {
+        const w = parseInt(maxWidthInput.value, 10) || 0;
+        maxHeightInput.value = w * 2;
+      }
+    };
+
+    verticalRatioToggle.addEventListener('change', updateVerticalRatio);
+    if (maxWidthInput) maxWidthInput.addEventListener('input', updateVerticalRatio);
+  }
 }
 
 // Initialize everything when DOM is loaded
@@ -1188,6 +1215,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   maxHeightInput = document.getElementById('max-height');
   qualityInput = document.getElementById('quality');
   outputFormatInput = document.getElementById('output-format');
+  resolutionPreset = document.getElementById('resolution-preset');
+  verticalRatioToggle = document.getElementById('toggle-vertical-2-1');
   progressStatus = document.getElementById('progress-status');
   progressBar = document.getElementById('progress-bar');
   convertImagesBtn = document.getElementById('convert-images-btn');

--- a/index.html
+++ b/index.html
@@ -107,6 +107,23 @@
         <input id="quality" type="number" min="0.1" max="1" step="0.01" value="0.95" class="w-20 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
         <span class="text-gray-500">(0.1 - 1)</span>
       </div>
+      <div class="bg-white rounded shadow px-3 py-2 flex items-center gap-2">
+        <label for="resolution-preset" class="font-medium">Preset:</label>
+        <select id="resolution-preset" class="border rounded px-2 py-1" style="background-color:var(--background);color:var(--foreground);border:1.5px solid var(--foreground);">
+          <option value="">Custom</option>
+          <option value="1920x1080">1920x1080</option>
+          <option value="1280x720">1280x720</option>
+          <option value="1080x1920">1080x1920</option>
+          <option value="1080x1080">1080x1080</option>
+          <option value="1080x2160">1080x2160 (2:1)</option>
+        </select>
+      </div>
+      <div class="bg-white rounded shadow px-3 py-2 flex items-center gap-2">
+        <label class="font-medium flex items-center gap-1" for="toggle-vertical-2-1">
+          <input type="checkbox" id="toggle-vertical-2-1" class="rounded">
+          Vertical 2:1
+        </label>
+      </div>
     </div>
     <div id="format-controls" class="flex justify-center mb-4">
       <label for="output-format" class="font-medium mr-2">Output Format:</label>

--- a/styles.css
+++ b/styles.css
@@ -175,13 +175,16 @@ img.preview {
     max-width: 90%;
   }
   #controls {
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
     gap: 1rem;
     padding: 1rem 1.5rem;
   }
   #controls > div {
-    width: auto;
+    flex: 1 1 45%;
+    max-width: 300px;
     justify-content: flex-start;
     padding: 1rem 1.5rem;
     gap: 0.75rem;


### PR DESCRIPTION
## Summary
- enable horizontal layout of width/height controls on small screens
- add preset resolution selector and vertical 2:1 toggle
- update event listeners in `core.js` to apply preset and ratio selections

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687e98db65c083338cbaf38a7fcc34a6