### PR TITLE
Fix sidebar layout and rename ads preview

### DIFF
--- a/google-ads-rsa-preview.html
+++ b/google-ads-rsa-preview.html
@@ -654,22 +654,19 @@
   <!-- Page Layout -->
   <div class="flex flex-grow">
     <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-30"></div>
-    <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40 md:translate-x-0">
-    <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-30 md:hidden"></div>
-    <aside id="sidebar" class="fixed md:static top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full md:translate-x-0 transition-transform z-40">
+    <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <h2 class="text-lg font-bold mb-4" style="color:var(--foreground);">Tools</h2>
       <input id="tool-search" type="text" placeholder="Search" class="w-full mb-4 px-2 py-1 rounded border border-[var(--foreground)] bg-transparent" />
       <ul id="tool-list" class="space-y-2">
         <li><a href="index.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Image Converter</a></li>
-        <li><a href="Google Ads RSA Preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
+        <li><a href="google-ads-rsa-preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">
         <a href="request-tool.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Request a Tool</a>
       </div>
     </aside>
-<main id="main-content" class="flex-grow p-4">
-<main class="flex-grow p-4">
+    <main id="main-content" class="flex-grow p-4">
 
 <div class="container">
     <div class="header">
@@ -1289,48 +1286,6 @@ let imageAssetDataUrl = '';
     </div>
   </footer>
       
-  </body>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const sidebar = document.getElementById('sidebar');
-      const sidebarToggle = document.getElementById('sidebar-toggle');
-      const sidebarOverlay = document.getElementById('sidebar-overlay');
-      const toolSearch = document.getElementById('tool-search');
-      const toolList = document.getElementById('tool-list');
-
-      if (sidebarToggle) {
-        sidebarToggle.addEventListener('click', () => {
-          const isOpen = !sidebar.classList.contains('-translate-x-full');
-          if (isOpen) {
-            sidebar.classList.add('-translate-x-full');
-            sidebarToggle.innerHTML = '<i class="fas fa-bars"></i>';
-            if (sidebarOverlay) sidebarOverlay.classList.add('hidden');
-          } else {
-            sidebar.classList.remove('-translate-x-full');
-            sidebarToggle.innerHTML = '<i class="fas fa-times"></i>';
-            if (sidebarOverlay) sidebarOverlay.classList.remove('hidden');
-          }
-        });
-      }
-
-      if (sidebarOverlay) {
-        sidebarOverlay.addEventListener('click', () => {
-          sidebar.classList.add('-translate-x-full');
-          sidebarToggle.innerHTML = '<i class="fas fa-bars"></i>';
-          sidebarOverlay.classList.add('hidden');
-        });
-      }
-
-      if (toolSearch && toolList) {
-        toolSearch.addEventListener('input', () => {
-          const term = toolSearch.value.toLowerCase();
-          toolList.querySelectorAll('li').forEach(li => {
-            const text = li.textContent.toLowerCase();
-            li.style.display = text.includes(term) ? '' : 'none';
-          });
-        });
-      }
-    });
-  </script>
+  <!-- layout.js handles sidebar functionality -->
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -61,12 +61,12 @@
   <!-- Page Layout -->
   <div class="flex flex-grow">
     <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-30"></div>
-    <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40 md:translate-x-0">
+    <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <h2 class="text-lg font-bold mb-4" style="color:var(--foreground);">Tools</h2>
       <input id="tool-search" type="text" placeholder="Search" class="w-full mb-4 px-2 py-1 rounded border border-[var(--foreground)] bg-transparent" />
       <ul id="tool-list" class="space-y-2">
         <li><a href="index.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Image Converter</a></li>
-        <li><a href="Google Ads RSA Preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
+        <li><a href="google-ads-rsa-preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/layout.js
+++ b/layout.js
@@ -4,38 +4,24 @@ document.addEventListener('DOMContentLoaded', () => {
   const sidebarOverlay = document.getElementById('sidebar-overlay');
   const toolSearch = document.getElementById('tool-search');
   const toolList = document.getElementById('tool-list');
-  const mainContent = document.getElementById('main-content');
-
-  function updateMainOffset() {
-    if (!mainContent) return;
-    const isOpen = !sidebar.classList.contains('-translate-x-full');
-    if (isOpen) {
-      mainContent.classList.add('md:pl-64');
-    } else {
-      mainContent.classList.remove('md:pl-64');
-    }
-  }
+  // Sidebar remains overlayed across breakpoints so no main content offset is
+  // needed.
 
   function openSidebar() {
     sidebar.classList.remove('-translate-x-full');
     sidebarToggle.innerHTML = '<i class="fas fa-times"></i>';
-    if (window.innerWidth < 768 && sidebarOverlay) sidebarOverlay.classList.remove('hidden');
-    updateMainOffset();
+    if (sidebarOverlay) sidebarOverlay.classList.remove('hidden');
   }
 
   function closeSidebar() {
     sidebar.classList.add('-translate-x-full');
     sidebarToggle.innerHTML = '<i class="fas fa-bars"></i>';
     if (sidebarOverlay) sidebarOverlay.classList.add('hidden');
-    updateMainOffset();
   }
 
   if (sidebar && sidebarToggle) {
-    if (window.innerWidth >= 768) {
-      openSidebar();
-    } else {
-      closeSidebar();
-    }
+    // Start closed on all screen sizes for consistent behavior.
+    closeSidebar();
 
     sidebarToggle.addEventListener('click', () => {
       const isOpen = !sidebar.classList.contains('-translate-x-full');

--- a/request-tool.html
+++ b/request-tool.html
@@ -36,17 +36,13 @@
 
   <!-- Page Layout -->
   <div class="flex flex-grow">
-
     <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-30"></div>
-    <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40 md:translate-x-0">
-
-    <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-30 md:hidden"></div>
-    <aside id="sidebar" class="fixed md:static top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full md:translate-x-0 transition-transform z-40">
+    <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <h2 class="text-lg font-bold mb-4" style="color:var(--foreground);">Tools</h2>
       <input id="tool-search" type="text" placeholder="Search" class="w-full mb-4 px-2 py-1 rounded border border-[var(--foreground)] bg-transparent" />
       <ul id="tool-list" class="space-y-2">
         <li><a href="index.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Image Converter</a></li>
-        <li><a href="Google Ads RSA Preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
+        <li><a href="google-ads-rsa-preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">
@@ -54,8 +50,6 @@
       </div>
     </aside>
     <main id="main-content" class="flex-grow p-4">
-
-    <main class="flex-grow p-4">
 
       <h1 class="text-3xl font-bold mb-4" style="color:var(--foreground);">Request a Tool</h1>
       <p style="color:var(--foreground);">Let us know what tool you'd like us to build next.</p>
@@ -73,47 +67,6 @@
     </div>
   </footer>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const sidebar = document.getElementById('sidebar');
-      const sidebarToggle = document.getElementById('sidebar-toggle');
-      const sidebarOverlay = document.getElementById('sidebar-overlay');
-      const toolSearch = document.getElementById('tool-search');
-      const toolList = document.getElementById('tool-list');
-
-      if (sidebarToggle) {
-        sidebarToggle.addEventListener('click', () => {
-          const isOpen = !sidebar.classList.contains('-translate-x-full');
-          if (isOpen) {
-            sidebar.classList.add('-translate-x-full');
-            sidebarToggle.innerHTML = '<i class="fas fa-bars"></i>';
-            if (sidebarOverlay) sidebarOverlay.classList.add('hidden');
-          } else {
-            sidebar.classList.remove('-translate-x-full');
-            sidebarToggle.innerHTML = '<i class="fas fa-times"></i>';
-            if (sidebarOverlay) sidebarOverlay.classList.remove('hidden');
-          }
-        });
-      }
-
-      if (sidebarOverlay) {
-        sidebarOverlay.addEventListener('click', () => {
-          sidebar.classList.add('-translate-x-full');
-          sidebarToggle.innerHTML = '<i class="fas fa-bars"></i>';
-          sidebarOverlay.classList.add('hidden');
-        });
-      }
-
-      if (toolSearch && toolList) {
-        toolSearch.addEventListener('input', () => {
-          const term = toolSearch.value.toLowerCase();
-          toolList.querySelectorAll('li').forEach(li => {
-            const text = li.textContent.toLowerCase();
-            li.style.display = text.includes(term) ? '' : 'none';
-          });
-        });
-      }
-    });
-  </script>
+  <!-- layout.js handles sidebar functionality -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep sidebar closed by default and overlay it at all widths
- remove desktop-specific classes from sidebar markup
- rename Google Ads RSA Preview page to use hyphenated filename

## Testing
- `node -c layout.js`

------
https://chatgpt.com/codex/tasks/task_e_687f0715b5b48333834c69444e99336e