### PR TITLE
Add word to parts of speech tool

### DIFF
--- a/google-ads-rsa-preview.html
+++ b/google-ads-rsa-preview.html
@@ -660,6 +660,7 @@
       <ul id="tool-list" class="space-y-2">
         <li><a href="index.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Image Converter</a></li>
         <li><a href="google-ads-rsa-preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
+        <li><a href="pos-tool.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Word to Parts of Speech</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
       <ul id="tool-list" class="space-y-2">
         <li><a href="index.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Image Converter</a></li>
         <li><a href="google-ads-rsa-preview.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Google Ads RSA Preview</a></li>
+        <li><a href="pos-tool.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Word to Parts of Speech</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/pos-tool.html
+++ b/pos-tool.html
@@ -3,13 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Request a Tool</title>
+  <title>Word to Parts of Speech</title>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <script type="module" src="theme.js"></script>
   <script type="module" src="layout.js"></script>
+  <script type="module" src="pos-tool.js"></script>
 </head>
 <body class="bg-transparent min-h-screen flex flex-col">
   <!-- Navigation Bar -->
@@ -51,11 +52,18 @@
       </div>
     </aside>
     <main id="main-content" class="flex-grow p-4">
+      <h1 class="text-3xl font-bold mb-4" style="color:var(--foreground);">Word to Parts of Speech</h1>
+      <div class="space-y-4 max-w-md">
+        <input id="word-input" type="text" placeholder="Enter a word" class="shad-input" />
+        <button id="analyze-btn" class="shad-btn">Analyze</button>
+        <div id="scoreboard" class="text-[var(--foreground)]">Stage: <span id="stage">Bronze</span> | Points: <span id="points">0</span></div>
+        <div id="result" class="mt-4 text-[var(--foreground)]"></div>
+      </div>
 
-      <h1 class="text-3xl font-bold mb-4" style="color:var(--foreground);">Request a Tool</h1>
-      <p style="color:var(--foreground);">Let us know what tool you'd like us to build next.</p>
-      <div id="request-tool-embed" class="my-8">
-        <!-- loops.so embed code will be inserted here -->
+      <div id="quiz-container" class="mt-8 hidden">
+        <h2 class="text-xl font-bold mb-2" style="color:var(--foreground);">Quiz Time!</h2>
+        <form id="quiz-form" class="space-y-4"></form>
+        <div id="quiz-result" class="mt-4 text-[var(--foreground)]"></div>
       </div>
     </main>
   </div>

--- a/pos-tool.js
+++ b/pos-tool.js
@@ -1,0 +1,120 @@
+// pos-tool.js - Word to Parts of Speech tool
+
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('word-input');
+  const btn = document.getElementById('analyze-btn');
+  const result = document.getElementById('result');
+  const quizContainer = document.getElementById('quiz-container');
+  const quizForm = document.getElementById('quiz-form');
+  const quizResult = document.getElementById('quiz-result');
+  const pointsEl = document.getElementById('points');
+  const stageEl = document.getElementById('stage');
+
+  const searchedWords = [];
+  const partsMap = {};
+  let points = 0;
+  let correctCount = 0;
+
+  function updateScoreboard() {
+    pointsEl.textContent = points;
+    if (correctCount >= 15) stageEl.textContent = 'Gold';
+    else if (points >= 50) stageEl.textContent = 'Silver';
+    else stageEl.textContent = 'Bronze';
+  }
+
+  updateScoreboard();
+
+  async function analyze() {
+    const word = input.value.trim().toLowerCase();
+    if (!word) {
+      result.textContent = 'Please enter a word.';
+      return;
+    }
+    result.textContent = 'Loading...';
+    try {
+      const resp = await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${encodeURIComponent(word)}`);
+      if (!resp.ok) throw new Error('Not found');
+      const data = await resp.json();
+      if (!Array.isArray(data) || !data.length || !data[0].meanings || !data[0].meanings.length) {
+        throw new Error('No results');
+      }
+      const meaning = data[0].meanings[0];
+      const part = meaning.partOfSpeech;
+      const definition = meaning.definitions[0].definition;
+
+      let example = meaning.definitions.find(d => d.example)?.example;
+      if (!example) example = `Here is an example sentence using the word "${word}".`;
+
+      const synSet = new Set();
+      meaning.definitions.forEach(d => {
+        if (Array.isArray(d.synonyms)) d.synonyms.forEach(s => synSet.add(s));
+      });
+      if (Array.isArray(meaning.synonyms)) meaning.synonyms.forEach(s => synSet.add(s));
+
+      const synonyms = Array.from(synSet).slice(0, 5); // limit display
+
+      result.innerHTML = `
+        <div class="border rounded p-4">
+          <div class="text-xl font-semibold">${word}</div>
+          <div class="italic mb-2">${part}</div>
+          <div>${definition}</div>
+          <div class="mt-2 text-sm">Example: ${example}</div>
+          ${synonyms.length ? `<div class="mt-2 text-sm">Similar: ${synonyms.join(', ')}</div>` : ''}
+        </div>`;
+
+      // store for quiz
+      partsMap[word] = part;
+      if (!searchedWords.includes(word)) searchedWords.push(word);
+      if (searchedWords.length > 3) searchedWords.shift();
+      if (searchedWords.length === 3) buildQuiz();
+
+    } catch (err) {
+      result.textContent = 'Sorry, could not find that word.';
+    }
+  }
+
+  function buildQuiz() {
+    quizForm.innerHTML = '';
+    searchedWords.forEach(w => {
+      quizForm.innerHTML += `
+        <div>
+          <label class="block mb-1" for="${w}">${w}</label>
+          <select id="${w}" name="${w}" class="shad-input">
+            <option value="noun">Noun</option>
+            <option value="verb">Verb</option>
+            <option value="adjective">Adjective</option>
+            <option value="adverb">Adverb</option>
+            <option value="pronoun">Pronoun</option>
+            <option value="preposition">Preposition</option>
+            <option value="conjunction">Conjunction</option>
+            <option value="interjection">Interjection</option>
+            <option value="determiner">Determiner</option>
+            <option value="other">Other</option>
+          </select>
+        </div>`;
+    });
+    quizForm.innerHTML += '<button type="submit" class="shad-btn">Submit Answers</button>';
+    quizContainer.classList.remove('hidden');
+  }
+
+  quizForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    let correct = 0;
+    searchedWords.forEach(w => {
+      const ans = quizForm.elements[w].value.toLowerCase();
+      const actual = partsMap[w]?.toLowerCase() || '';
+      if (ans === actual) correct += 1;
+    });
+    points += correct * 10;
+    correctCount += correct;
+    updateScoreboard();
+    quizResult.textContent = `You got ${correct} out of ${searchedWords.length} correct!`;
+    searchedWords.length = 0;
+    quizContainer.classList.add('hidden');
+  });
+
+  btn.addEventListener('click', analyze);
+  input.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') analyze();
+  });
+});


### PR DESCRIPTION
## Summary
- add a new page `pos-tool.html` with a simple form for checking a word's part of speech
- create `pos-tool.js` which calls an open dictionary API to fetch the part of speech and an example sentence
- link the new tool in the sidebar of all pages
- expand the tool to show definitions, similar words, and a quiz after three lookups

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fbcf79fb48333a412dc7bf5077ed0