### PR TITLE
Clean duplicate sections across pages

### DIFF
--- a/campaign-structure.html
+++ b/campaign-structure.html
@@ -4,9 +4,6 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-NFJTSQ3N');</script>
   <!-- End Google Tag Manager -->
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Google Ads Campaign Structure</title>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,8 +19,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-FYavDG4SJo6P4iINafSCi6SMnF47QlvJwFSc1aHs+qlhK/SXxPxq8np5xpoE2mR7BncpsbR9f7D28iOQNp3Npg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 <body data-slug="campaign-structure" class="bg-transparent min-h-screen flex flex-col">
-</head>
-<body class="bg-transparent min-h-screen flex flex-col">
+
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/google-ads-rsa-preview.html
+++ b/google-ads-rsa-preview.html
@@ -633,7 +633,6 @@
     </style>
 </head>
 <body data-slug="google-ads-rsa-preview" class="bg-transparent min-h-screen flex flex-col">
-<body class="bg-transparent min-h-screen flex flex-col">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/image-converter.html
+++ b/image-converter.html
@@ -8,9 +8,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Image to WebP Converter</title>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Image to WebP Converter</title>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
@@ -33,10 +30,6 @@
   <script type="module" src="layout.js"></script>
 </head>
 <body data-slug="image-converter" class="bg-transparent min-h-screen flex flex-col">
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-<body class="bg-transparent min-h-screen flex flex-col">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
@@ -136,7 +129,6 @@
     </div>
     <div id="format-options" class="flex justify-center gap-4 mb-4" style="display:none;"></div>
     <div id="progress-status" class="text-center text-lg font-medium mb-2" style="color:var(--foreground);"></div>
-    <div id="progress-status" class="text-center text-lg font-medium mb-2" style="color:#cde5da;"></div>
     <div id="progress-bar-container" class="w-full max-w-2xl mx-auto mb-4">
       <div id="progress-bar"></div>
     </div>
@@ -306,7 +298,6 @@
     <div class="overflow-x-auto max-w-5xl mx-auto px-2 sm:px-4 min-w-0">
       <table id="preview-table" class="min-w-full w-full mb-8 text-sm sm:text-base table-auto" style="background: transparent;">
         <thead class="hidden md:table-header-group">
-        <thead>
           <tr>
             <th class="py-2 px-2 sm:px-4"><input type="checkbox" id="select-all"></th>
             <th class="py-2 px-2 sm:px-4">#</th>
@@ -323,32 +314,6 @@
 
     <!-- Hide card grid -->
     <div id="preview-grid" style="display:none;"></div>
-    <section id="faqs" class="mt-8 space-y-4 max-w-xl mx-auto">
-      <h2 class="text-2xl font-bold" style="color:var(--foreground);">Image Converter FAQs</h2>
-      <details class="border p-2 rounded">
-        <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">How do I convert images to WebP?</summary>
-        <p class="mt-2" style="color:var(--foreground);">Upload your files, choose WebP as the output format and click convert. Our free online image converter will handle the rest.</p>
-      </details>
-      <details class="border p-2 rounded">
-        <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Can I convert HEIC photos from my iPhone?</summary>
-        <p class="mt-2" style="color:var(--foreground);">Yes, the tool converts HEIC images to popular formats like JPEG or PNG so you can easily share them.</p>
-      </details>
-      <details class="border p-2 rounded">
-        <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Does the converter work for large batches?</summary>
-        <p class="mt-2" style="color:var(--foreground);">You can upload multiple pictures at once and download everything as a ZIP after the conversion finishes.</p>
-      </details>
-      <details class="border p-2 rounded">
-        <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Is this image converter free?</summary>
-        <p class="mt-2" style="color:var(--foreground);">The basic conversion features are free and run directly in your browser.</p>
-      </details>
-      <details class="border p-2 rounded">
-        <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Why convert to WebP or AVIF?</summary>
-        <p class="mt-2" style="color:var(--foreground);">Modern formats like WebP and AVIF offer better compression so your pages load faster with smaller file sizes.</p>
-      </details>
-      <details class="border p-2 rounded">
-        <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Does processing happen online?</summary>
-        <p class="mt-2" style="color:var(--foreground);">All conversion happens locally in your browser; images never leave your computer.</p>
-      </details>
     <section id="faqs" class="max-w-5xl mx-auto px-4 py-8">
       <h2 class="text-2xl font-bold mb-4" style="color:var(--foreground);">Image Converter FAQs</h2>
       <div class="space-y-2">

--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>reformately Tools</title>-of-speech-tool
-  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
+  <title>reformately Tools</title>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -18,9 +17,6 @@
   <script type="module" src="home.js"></script>
 </head>
 <body class="bg-transparent min-h-screen flex flex-col">
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
@@ -111,33 +107,6 @@
         <a href="bulk-match-editor.html" class="tool-card border rounded p-4" data-name="Bulk Match Type Editor" data-category="Marketing" data-slug="bulk-match-editor">
           <h3 class="font-semibold mb-1" style="color:var(--foreground);">Bulk Match Type Editor</h3>
           <p class="text-sm" style="color:var(--foreground);">Convert keywords to phrase and exact match.</p>
-        </a>
-      </div>
-      <div class="max-w-7xl mx-auto">
-      <section class="text-center py-12">
-        <h1 class="text-4xl font-bold mb-2" style="color:var(--foreground);">Welcome to reformately</h1>
-        <p class="text-lg" style="color:var(--foreground);">A collection of handy online tools</p>
-      </section>
-      <div class="max-w-md mx-auto mb-8">
-        <input id="home-search" type="text" placeholder="Search tools" class="shad-input" />
-      </div>
-      <div id="home-tools" class="grid gap-4 md:grid-cols-2">
-      <div id="home-tools" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <a href="image-converter.html" class="tool-card border rounded p-4" data-name="Image Converter" data-category="Images">
-          <h3 class="font-semibold mb-1" style="color:var(--foreground);">Image Converter</h3>
-          <p class="text-sm" style="color:var(--foreground);">Convert images between formats.</p>
-        </a>
-        <a href="google-ads-rsa-preview.html" class="tool-card border rounded p-4" data-name="Google Ads RSA Preview" data-category="Marketing">
-          <h3 class="font-semibold mb-1" style="color:var(--foreground);">Google Ads RSA Preview</h3>
-          <p class="text-sm" style="color:var(--foreground);">Visualize responsive search ads.</p>
-        </a>
-        <a href="pos-tool.html" class="tool-card border rounded p-4" data-name="Word to Parts of Speech" data-category="Writing">
-          <h3 class="font-semibold mb-1" style="color:var(--foreground);">Word to Parts of Speech</h3>
-          <p class="text-sm" style="color:var(--foreground);">Identify a word's part of speech.</p>
-        </a>
-        <a href="campaign-structure.html" class="tool-card border rounded p-4" data-name="Campaign Structure" data-category="Marketing">
-          <h3 class="font-semibold mb-1" style="color:var(--foreground);">Campaign Structure</h3>
-          <p class="text-sm" style="color:var(--foreground);">Visualize ad campaign hierarchy.</p>
         </a>
       </div>
       </div>

--- a/pos-tool.html
+++ b/pos-tool.html
@@ -4,9 +4,6 @@
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-NFJTSQ3N');</script>
   <!-- End Google Tag Manager -->
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Word to Parts of Speech</title>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -20,10 +17,6 @@
   <script type="module" src="pos-tool.js"></script>
 </head>
 <body data-slug="pos-tool" class="bg-transparent min-h-screen flex flex-col">
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-<body class="bg-transparent min-h-screen flex flex-col">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/request-tool.html
+++ b/request-tool.html
@@ -16,7 +16,6 @@
   <script type="module" src="layout.js"></script>
 </head>
 <body data-slug="request-tool" class="bg-transparent min-h-screen flex flex-col">
-<body class="bg-transparent min-h-screen flex flex-col">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->


### PR DESCRIPTION
## Summary
- deduplicate Google Tag Manager snippets and theme setup
- drop repeated sections on the homepage
- fix repeated `<body>` tags on several pages
- remove duplicate FAQ blocks and extra table headers

## Testing
- `npx htmlhint index.html` *(fails: Unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_688202ad73ac83338365e6bcec9d8dc6