### PR TITLE
Fix homepage tool sorting and filtering

### DIFF
--- a/home.js
+++ b/home.js
@@ -31,13 +31,4 @@ document.addEventListener('DOMContentLoaded', () => {
   if (category) category.addEventListener('change', render);
   if (sort) sort.addEventListener('change', render);
   render();
-  if (!search) return;
-  const cards = document.querySelectorAll('.tool-card');
-  search.addEventListener('input', () => {
-    const term = search.value.toLowerCase();
-    cards.forEach(card => {
-      const text = card.dataset.name.toLowerCase() + ' ' + card.dataset.category.toLowerCase();
-      card.style.display = text.includes(term) ? '' : 'none';
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- remove duplicate search event handler that overwrote filtering and sorting

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688288b9c3d88333b3ea911a4de21c5a