### PR TITLE
Add more keyword match options

### DIFF
--- a/bulk-match-editor.html
+++ b/bulk-match-editor.html
@@ -70,9 +70,39 @@
         <p class="mb-4" style="color:var(--foreground);">Enter your keywords below and generate phrase and exact match versions. Select rows to copy specific terms or copy the entire list at once.</p>
         <div class="space-y-4">
           <textarea id="keywords-input" rows="5" class="shad-input" placeholder="Enter keywords, one per line"></textarea>
-          <button id="convert-btn" class="shad-btn">Convert</button>
+          <div class="flex flex-wrap gap-4 items-center">
+            <label class="inline-flex items-center" style="color:var(--foreground);">
+              <input id="mb-option" type="checkbox" class="mr-2">
+              Modified broad match
+            </label>
+            <label class="inline-flex items-center" style="color:var(--foreground);">
+              <input id="neg-option" type="checkbox" class="mr-2">
+              Generate negatives
+            </label>
+            <button id="convert-btn" class="shad-btn ml-auto">Convert</button>
+          </div>
           <div id="results-section" class="hidden mt-6 space-y-4">
-            <div class="grid gap-4 md:grid-cols-2">
+            <div id="positive-grid" class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <div id="broad-col" class="hidden">
+                <h2 class="text-xl font-semibold mb-2" style="color:var(--foreground);">Broad Match</h2>
+                <div class="flex justify-between items-center mb-2">
+                  <span id="broad-count" class="text-sm" style="color:var(--foreground);">0 selected</span>
+                  <button id="copy-broad-btn" class="shad-btn" disabled>Copy all</button>
+                </div>
+                <table class="min-w-full text-sm border border-[var(--foreground)]/20">
+                  <tbody id="broad-body"></tbody>
+                </table>
+              </div>
+              <div id="mb-col" class="hidden">
+                <h2 class="text-xl font-semibold mb-2" style="color:var(--foreground);">Modified Broad</h2>
+                <div class="flex justify-between items-center mb-2">
+                  <span id="mb-count" class="text-sm" style="color:var(--foreground);">0 selected</span>
+                  <button id="copy-mb-btn" class="shad-btn" disabled>Copy all</button>
+                </div>
+                <table class="min-w-full text-sm border border-[var(--foreground)]/20">
+                  <tbody id="mb-body"></tbody>
+                </table>
+              </div>
               <div>
                 <h2 class="text-xl font-semibold mb-2" style="color:var(--foreground);">Phrase Match</h2>
                 <div class="flex justify-between items-center mb-2">
@@ -93,6 +123,54 @@
                   <tbody id="exact-body"></tbody>
                 </table>
               </div>
+            </div>
+            <div id="negative-wrapper" class="hidden space-y-4">
+              <h2 class="text-xl font-semibold" style="color:var(--foreground);">Negative Keywords</h2>
+              <div id="negative-grid" class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <div id="nbroad-col" class="hidden">
+                  <h3 class="font-semibold mb-2" style="color:var(--foreground);">Broad</h3>
+                  <div class="flex justify-between items-center mb-2">
+                    <span id="nbroad-count" class="text-sm" style="color:var(--foreground);">0 selected</span>
+                    <button id="copy-nbroad-btn" class="shad-btn" disabled>Copy all</button>
+                  </div>
+                  <table class="min-w-full text-sm border border-[var(--foreground)]/20">
+                    <tbody id="nbroad-body"></tbody>
+                  </table>
+                </div>
+                <div id="nmb-col" class="hidden">
+                  <h3 class="font-semibold mb-2" style="color:var(--foreground);">Modified Broad</h3>
+                  <div class="flex justify-between items-center mb-2">
+                    <span id="nmb-count" class="text-sm" style="color:var(--foreground);">0 selected</span>
+                    <button id="copy-nmb-btn" class="shad-btn" disabled>Copy all</button>
+                  </div>
+                  <table class="min-w-full text-sm border border-[var(--foreground)]/20">
+                    <tbody id="nmb-body"></tbody>
+                  </table>
+                </div>
+                <div id="nphrase-col">
+                  <h3 class="font-semibold mb-2" style="color:var(--foreground);">Phrase</h3>
+                  <div class="flex justify-between items-center mb-2">
+                    <span id="nphrase-count" class="text-sm" style="color:var(--foreground);">0 selected</span>
+                    <button id="copy-nphrase-btn" class="shad-btn" disabled>Copy all</button>
+                  </div>
+                  <table class="min-w-full text-sm border border-[var(--foreground)]/20">
+                    <tbody id="nphrase-body"></tbody>
+                  </table>
+                </div>
+                <div id="nexact-col">
+                  <h3 class="font-semibold mb-2" style="color:var(--foreground);">Exact</h3>
+                  <div class="flex justify-between items-center mb-2">
+                    <span id="nexact-count" class="text-sm" style="color:var(--foreground);">0 selected</span>
+                    <button id="copy-nexact-btn" class="shad-btn" disabled>Copy all</button>
+                  </div>
+                  <table class="min-w-full text-sm border border-[var(--foreground)]/20">
+                    <tbody id="nexact-body"></tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <div class="text-right">
+              <button id="export-csv-btn" class="shad-btn" disabled>Export CSV</button>
             </div>
           </div>
           <section class="mt-8 space-y-4">

--- a/bulk-match-editor.js
+++ b/bulk-match-editor.js
@@ -4,49 +4,138 @@ document.addEventListener('DOMContentLoaded', () => {
   const textarea = document.getElementById('keywords-input');
   const convertBtn = document.getElementById('convert-btn');
   const resultsSection = document.getElementById('results-section');
-  const phraseBody = document.getElementById('phrase-body');
-  const exactBody = document.getElementById('exact-body');
-  const phraseCount = document.getElementById('phrase-count');
-  const exactCount = document.getElementById('exact-count');
-  const copyPhraseBtn = document.getElementById('copy-phrase-btn');
-  const copyExactBtn = document.getElementById('copy-exact-btn');
+  const mbOption = document.getElementById('mb-option');
+  const negOption = document.getElementById('neg-option');
+  const exportBtn = document.getElementById('export-csv-btn');
+
+  const sections = {
+    broad: {
+      container: document.getElementById('broad-col'),
+      body: document.getElementById('broad-body'),
+      count: document.getElementById('broad-count'),
+      copyBtn: document.getElementById('copy-broad-btn')
+    },
+    mb: {
+      container: document.getElementById('mb-col'),
+      body: document.getElementById('mb-body'),
+      count: document.getElementById('mb-count'),
+      copyBtn: document.getElementById('copy-mb-btn')
+    },
+    phrase: {
+      container: null,
+      body: document.getElementById('phrase-body'),
+      count: document.getElementById('phrase-count'),
+      copyBtn: document.getElementById('copy-phrase-btn')
+    },
+    exact: {
+      container: null,
+      body: document.getElementById('exact-body'),
+      count: document.getElementById('exact-count'),
+      copyBtn: document.getElementById('copy-exact-btn')
+    },
+    nbroad: {
+      container: document.getElementById('nbroad-col'),
+      body: document.getElementById('nbroad-body'),
+      count: document.getElementById('nbroad-count'),
+      copyBtn: document.getElementById('copy-nbroad-btn')
+    },
+    nmb: {
+      container: document.getElementById('nmb-col'),
+      body: document.getElementById('nmb-body'),
+      count: document.getElementById('nmb-count'),
+      copyBtn: document.getElementById('copy-nmb-btn')
+    },
+    nphrase: {
+      container: document.getElementById('nphrase-col'),
+      body: document.getElementById('nphrase-body'),
+      count: document.getElementById('nphrase-count'),
+      copyBtn: document.getElementById('copy-nphrase-btn')
+    },
+    nexact: {
+      container: document.getElementById('nexact-col'),
+      body: document.getElementById('nexact-body'),
+      count: document.getElementById('nexact-count'),
+      copyBtn: document.getElementById('copy-nexact-btn')
+    }
+  };
 
   function updateCounts() {
-    const phraseSelected = phraseBody.querySelectorAll('.kw-select:checked').length;
-    const exactSelected = exactBody.querySelectorAll('.kw-select:checked').length;
-    phraseCount.textContent = `${phraseSelected} selected`;
-    exactCount.textContent = `${exactSelected} selected`;
-    copyPhraseBtn.textContent = phraseSelected > 0 ? `Copy ${phraseSelected} selected` : 'Copy all';
-    copyExactBtn.textContent = exactSelected > 0 ? `Copy ${exactSelected} selected` : 'Copy all';
-    copyPhraseBtn.disabled = phraseBody.querySelectorAll('tr').length === 0;
-    copyExactBtn.disabled = exactBody.querySelectorAll('tr').length === 0;
+    Object.values(sections).forEach(sec => {
+      if (!sec.body) return;
+      const visible = !sec.container || !sec.container.classList.contains('hidden');
+      if (!visible) return;
+      const selected = sec.body.querySelectorAll('.kw-select:checked').length;
+      const total = sec.body.querySelectorAll('tr').length;
+      if (sec.count) sec.count.textContent = `${selected} selected`;
+      if (sec.copyBtn) {
+        sec.copyBtn.textContent = selected > 0 ? `Copy ${selected} selected` : 'Copy all';
+        sec.copyBtn.disabled = total === 0;
+      }
+    });
+    exportBtn.disabled = resultsSection.classList.contains('hidden');
+  }
+
+  function makeRow(text) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="border border-[var(--foreground)]/20 p-2 kw">${text}</td>
+      <td class="border border-[var(--foreground)]/20 p-2 text-center">
+        <input type="checkbox" class="kw-select">
+        <button class="copy-single ml-2" title="Copy"><i class="fas fa-copy"></i></button>
+      </td>`;
+    return tr;
   }
 
   function renderRows(keywords) {
-    phraseBody.innerHTML = '';
-    exactBody.innerHTML = '';
+    Object.values(sections).forEach(sec => {
+      if (sec.body) sec.body.innerHTML = '';
+    });
+
+    // Show/hide modified broad and negative sections
+    sections.broad.container.classList.remove('hidden');
+    if (mbOption.checked) {
+      sections.mb.container.classList.remove('hidden');
+    } else {
+      sections.mb.container.classList.add('hidden');
+    }
+
+    if (negOption.checked) {
+      document.getElementById('negative-wrapper').classList.remove('hidden');
+      sections.nbroad.container.classList.remove('hidden');
+      sections.nphrase.container.classList.remove('hidden');
+      sections.nexact.container.classList.remove('hidden');
+      if (mbOption.checked) {
+        sections.nmb.container.classList.remove('hidden');
+      } else {
+        sections.nmb.container.classList.add('hidden');
+      }
+    } else {
+      document.getElementById('negative-wrapper').classList.add('hidden');
+    }
+
     keywords.forEach(kw => {
+      sections.broad.body.appendChild(makeRow(kw));
+      if (mbOption.checked) {
+        const mbk = kw.split(/\s+/).map(w => `+${w}`).join(' ');
+        sections.mb.body.appendChild(makeRow(mbk));
+      }
       const phrase = `"${kw}"`;
       const exact = `[${kw}]`;
-      const pRow = document.createElement('tr');
-      pRow.innerHTML = `
-        <td class="border border-[var(--foreground)]/20 p-2 kw">${phrase}</td>
-        <td class="border border-[var(--foreground)]/20 p-2 text-center">
-          <input type="checkbox" class="kw-select">
-          <button class="copy-single ml-2" title="Copy"><i class="fas fa-copy"></i></button>
-        </td>`;
-      phraseBody.appendChild(pRow);
+      sections.phrase.body.appendChild(makeRow(phrase));
+      sections.exact.body.appendChild(makeRow(exact));
 
-      const eRow = document.createElement('tr');
-      eRow.innerHTML = `
-        <td class="border border-[var(--foreground)]/20 p-2 kw">${exact}</td>
-        <td class="border border-[var(--foreground)]/20 p-2 text-center">
-          <input type="checkbox" class="kw-select">
-          <button class="copy-single ml-2" title="Copy"><i class="fas fa-copy"></i></button>
-        </td>`;
-      exactBody.appendChild(eRow);
+      if (negOption.checked) {
+        sections.nbroad.body.appendChild(makeRow(`-${kw}`));
+        if (mbOption.checked) {
+          const mbNeg = kw.split(/\s+/).map(w => `+${w}`).join(' ');
+          sections.nmb.body.appendChild(makeRow(`-${mbNeg}`));
+        }
+        sections.nphrase.body.appendChild(makeRow(`-"${kw}"`));
+        sections.nexact.body.appendChild(makeRow(`-[${kw}]`));
+      }
     });
     resultsSection.classList.remove('hidden');
+    exportBtn.disabled = false;
     updateCounts();
   }
 
@@ -65,28 +154,63 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   convertBtn.addEventListener('click', () => {
-    const keywords = textarea.value.split(/\n+/).map(k => k.trim()).filter(Boolean);
+    const raw = textarea.value.split(/\n+/).map(k => k.trim()).filter(Boolean);
+    const seen = new Set();
+    const keywords = [];
+    raw.forEach(k => {
+      const lower = k.toLowerCase();
+      if (!seen.has(lower)) {
+        seen.add(lower);
+        keywords.push(k);
+      }
+    });
     if (!keywords.length) return;
     renderRows(keywords);
   });
 
-  phraseBody.addEventListener('change', updateCounts);
-  exactBody.addEventListener('change', updateCounts);
-
-  phraseBody.addEventListener('click', (e) => {
-    if (e.target.closest('.copy-single')) {
-      const text = e.target.closest('tr').querySelector('.kw').textContent;
-      navigator.clipboard.writeText(text).then(() => showNotification('Copied keyword', 'success'));
+  Object.values(sections).forEach(sec => {
+    if (!sec.body) return;
+    sec.body.addEventListener('change', updateCounts);
+    sec.body.addEventListener('click', e => {
+      if (e.target.closest('.copy-single')) {
+        const text = e.target.closest('tr').querySelector('.kw').textContent;
+        navigator.clipboard.writeText(text).then(() => showNotification('Copied keyword', 'success'));
+      }
+    });
+    if (sec.copyBtn) {
+      sec.copyBtn.addEventListener('click', () => copySelected(sec.body));
     }
   });
 
-  exactBody.addEventListener('click', (e) => {
-    if (e.target.closest('.copy-single')) {
-      const text = e.target.closest('tr').querySelector('.kw').textContent;
-      navigator.clipboard.writeText(text).then(() => showNotification('Copied keyword', 'success'));
+  exportBtn.addEventListener('click', () => {
+    const rows = [['Match Type', 'Keyword']];
+    const addSection = (label, sec) => {
+      if (sec.container && sec.container.classList.contains('hidden')) return;
+      Array.from(sec.body.querySelectorAll('.kw')).forEach(td => {
+        rows.push([label, td.textContent]);
+      });
+    };
+    addSection('Broad', sections.broad);
+    if (mbOption.checked) addSection('Modified Broad', sections.mb);
+    addSection('Phrase', sections.phrase);
+    addSection('Exact', sections.exact);
+    if (negOption.checked) {
+      addSection('Negative Broad', sections.nbroad);
+      if (mbOption.checked) addSection('Negative Modified Broad', sections.nmb);
+      addSection('Negative Phrase', sections.nphrase);
+      addSection('Negative Exact', sections.nexact);
     }
+    if (rows.length <= 1) return;
+    const csv = rows.map(r => r.map(v => `"${v.replace(/"/g, '""')}"`).join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'keywords.csv';
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   });
-
-  copyPhraseBtn.addEventListener('click', () => copySelected(phraseBody));
-  copyExactBtn.addEventListener('click', () => copySelected(exactBody));
 });


### PR DESCRIPTION
## Summary
- extend Bulk Match Type Editor with broad keywords and negatives
- add optional modified broad output
- export generated keywords as CSV
- deduplicate input keywords ignoring case

## Testing
- `node -c bulk-match-editor.js`

------
https://chatgpt.com/codex/tasks/task_e_688461644bbc8333af114d504a85fb3f