### PR TITLE
Add campaign structure editing features

### DIFF
--- a/campaign-structure.html
+++ b/campaign-structure.html
@@ -17,6 +17,7 @@
   <script type="module" src="campaign-structure.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNa72fmVK5GA6db6+mT6ytC/DWe8npAQK/2FqW0u35o3svynIogoZmY7z/F8xR0wZE9Q/3fWP8uyvN7v7uC4nw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-FYavDG4SJo6P4iINafSCi6SMnF47QlvJwFSc1aHs+qlhK/SXxPxq8np5xpoE2mR7BncpsbR9f7D28iOQNp3Npg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.15.0/Sortable.min.js"></script>
 </head>
 <body data-slug="campaign-structure" class="bg-transparent min-h-screen flex flex-col">
 
@@ -84,11 +85,16 @@
           <button type="submit" class="shad-btn">Generate Structure</button>
         </form>
 
-        <div id="structure-output" class="mt-6 text-[var(--foreground)]"></div>
-        <div id="download-buttons" class="mt-4 flex gap-4" style="display:none;">
-          <button id="download-png" class="shad-btn">Download PNG</button>
-          <button id="download-pdf" class="shad-btn">Download PDF</button>
-        </div>
+          <div id="structure-output" class="mt-6 text-[var(--foreground)]">
+            <div id="tree" class="bg-[var(--background)] border rounded p-4"></div>
+          </div>
+          <div id="download-buttons" class="mt-4 flex gap-4 hidden">
+            <button id="download-png" class="shad-btn">Download PNG</button>
+            <button id="download-pdf" class="shad-btn">Download PDF</button>
+            <button id="download-csv" class="shad-btn">Download CSV</button>
+          </div>
+
+
         <div class="mt-8">
           <h2 class="text-xl font-semibold mb-2" style="color:var(--foreground);">Naming Tips</h2>
           <ul class="list-disc list-inside text-[var(--foreground)]">

--- a/campaign-structure.js
+++ b/campaign-structure.js
@@ -1,11 +1,170 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('structure-form');
-  const output = document.getElementById('structure-output');
+  const tree = document.getElementById('tree');
   const downloadBtns = document.getElementById('download-buttons');
   const pngBtn = document.getElementById('download-png');
   const pdfBtn = document.getElementById('download-pdf');
-  if (!form) return;
-  form.addEventListener('submit', (e) => {
+  const csvBtn = document.getElementById('download-csv');
+  if (!form || !tree) return;
+
+  const campaigns = [];
+  let id = 0;
+  const nextId = () => 'id' + (++id);
+
+  function addEntry(type, campName, groupName, adName, keywords) {
+    let camp = campaigns.find(c => c.name === campName && c.type === type);
+    if (!camp) {
+      camp = { id: nextId(), type, name: campName, adGroups: [] };
+      campaigns.push(camp);
+    }
+    let group = camp.adGroups.find(g => g.name === groupName);
+    if (!group) {
+      group = { id: nextId(), name: groupName, ads: [] };
+      camp.adGroups.push(group);
+    }
+    group.ads.push({ id: nextId(), name: adName, keywords });
+  }
+
+  function makeEditable(el, onSave) {
+    el.addEventListener('dblclick', () => {
+      el.setAttribute('contenteditable', 'true');
+      el.focus();
+    });
+    el.addEventListener('blur', () => {
+      el.removeAttribute('contenteditable');
+      onSave(el.textContent.trim());
+    });
+    el.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        el.blur();
+      }
+    });
+  }
+
+  function render() {
+    tree.innerHTML = '';
+    const list = document.createElement('ul');
+    list.id = 'campaign-list';
+    list.className = 'space-y-2';
+    campaigns.forEach(c => {
+      const li = document.createElement('li');
+      li.dataset.id = c.id;
+      li.className = 'border rounded p-2';
+
+      const header = document.createElement('div');
+      header.className = 'flex items-center gap-2';
+      header.innerHTML = `<span class="drag-handle cursor-move">&#x2630;</span>
+        <span class="campaign-name cursor-pointer">${c.name}</span>
+        <span class="text-sm opacity-70">(${c.type})</span>`;
+      li.appendChild(header);
+      makeEditable(header.querySelector('.campaign-name'), val => { c.name = val; });
+
+      const agList = document.createElement('ul');
+      agList.className = 'ml-4 mt-2 space-y-2';
+      c.adGroups.forEach(g => {
+        const agLi = document.createElement('li');
+        agLi.dataset.id = g.id;
+        agLi.className = 'border rounded p-2';
+
+        const agHeader = document.createElement('div');
+        agHeader.className = 'flex items-center gap-2';
+        agHeader.innerHTML = `<span class="drag-handle cursor-move">&#x2630;</span>
+          <span class="adgroup-name cursor-pointer">${g.name}</span>`;
+        agLi.appendChild(agHeader);
+        makeEditable(agHeader.querySelector('.adgroup-name'), val => { g.name = val; });
+
+        const adList = document.createElement('ul');
+        adList.className = 'ml-4 mt-1 space-y-1';
+        g.ads.forEach(a => {
+          const adLi = document.createElement('li');
+          adLi.dataset.id = a.id;
+          adLi.className = 'border rounded p-2';
+          adLi.innerHTML = `<div class="flex items-center gap-2">
+              <span class="drag-handle cursor-move">&#x2630;</span>
+              <span class="ad-name cursor-pointer">${a.name}</span>
+            </div>
+            <div class="ml-6 text-sm opacity-70">Keywords: <span class="keywords">${a.keywords || '(none)'}</span></div>`;
+          makeEditable(adLi.querySelector('.ad-name'), val => { a.name = val; });
+          adList.appendChild(adLi);
+        });
+        agLi.appendChild(adList);
+        agList.appendChild(agLi);
+      });
+      li.appendChild(agList);
+      list.appendChild(li);
+    });
+    tree.appendChild(list);
+    setupSortables();
+    downloadBtns.classList.toggle('hidden', campaigns.length === 0);
+  }
+
+  function setupSortables() {
+    if (!window.Sortable) return;
+    const campList = document.getElementById('campaign-list');
+    if (!campList) return;
+    new Sortable(campList, {
+      handle: '.drag-handle',
+      animation: 150,
+      onEnd: e => {
+        const item = campaigns.splice(e.oldIndex, 1)[0];
+        campaigns.splice(e.newIndex, 0, item);
+      }
+    });
+    campaigns.forEach(c => {
+      const agList = document.querySelector(`li[data-id="${c.id}"] > ul`);
+      if (agList) {
+        new Sortable(agList, {
+          handle: '.drag-handle',
+          animation: 150,
+          onEnd: e => {
+            const arr = c.adGroups;
+            const item = arr.splice(e.oldIndex, 1)[0];
+            arr.splice(e.newIndex, 0, item);
+          }
+        });
+      }
+      c.adGroups.forEach(g => {
+        const adList = document.querySelector(`li[data-id="${g.id}"] > ul`);
+        if (adList) {
+          new Sortable(adList, {
+            handle: '.drag-handle',
+            animation: 150,
+            onEnd: e => {
+              const arr = g.ads;
+              const item = arr.splice(e.oldIndex, 1)[0];
+              arr.splice(e.newIndex, 0, item);
+            }
+          });
+        }
+      });
+    });
+  }
+
+  function exportCsv() {
+    const rows = [['Campaign','Ad Group','Ad Name','Keywords']];
+    campaigns.forEach(c => {
+      c.adGroups.forEach(g => {
+        g.ads.forEach(a => {
+          rows.push([c.name, g.name, a.name, a.keywords]);
+        });
+      });
+    });
+    if (rows.length <= 1) return;
+    const csv = rows.map(r => r.map(v => `"${(v || '').replace(/"/g,'""')}"`).join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'campaign-structure.csv';
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  form.addEventListener('submit', e => {
     e.preventDefault();
     const type = document.getElementById('campaign-type').value.trim();
     const campaign = document.getElementById('campaign-name').value.trim();
@@ -13,23 +172,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const ad = document.getElementById('ad-name').value.trim();
     const keywords = document.getElementById('keywords').value.trim();
     if (!campaign || !adGroup || !ad) {
-      output.textContent = 'Please fill in all fields.';
+      tree.textContent = 'Please fill in all fields.';
       return;
     }
-    output.innerHTML = `
-      <pre id="tree" class="bg-[var(--background)] border rounded p-4 font-mono overflow-x-auto">
-      <pre class="bg-[var(--background)] border rounded p-4 font-mono overflow-x-auto">
-<span class="text-blue-400 font-semibold">${campaign}</span>/ <span class="text-sm">(${type})</span>
-├── <span class="text-green-400 font-semibold">${adGroup}</span>/
-│   ├── <span class="text-yellow-300 font-semibold">${ad}</span>
-│   └── keywords: ${keywords || '(none)'}
-</pre>`;
-    downloadBtns.style.display = 'flex';
+    addEntry(type, campaign, adGroup, ad, keywords);
+    render();
   });
+
   if (pngBtn) {
     pngBtn.addEventListener('click', () => {
-      const tree = document.getElementById('tree');
-      if (!tree) return;
       html2canvas(tree).then(canvas => {
         const link = document.createElement('a');
         link.download = 'campaign-structure.png';
@@ -38,10 +189,9 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   }
+
   if (pdfBtn) {
     pdfBtn.addEventListener('click', () => {
-      const tree = document.getElementById('tree');
-      if (!tree) return;
       html2canvas(tree).then(canvas => {
         const imgData = canvas.toDataURL('image/png');
         const { jsPDF } = window.jspdf;
@@ -54,5 +204,6 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   }
-  });
+
+  if (csvBtn) csvBtn.addEventListener('click', exportCsv);
 });


### PR DESCRIPTION
## Summary
- add SortableJS to campaign structure page
- allow multiple ad groups, ads and campaigns with drag-and-drop
- inline name editing and CSV export

## Testing
- `node --check campaign-structure.js`

------
https://chatgpt.com/codex/tasks/task_e_688468ff90d48333bab2ebbcaab23f1c