### PR TITLE
Add FastAPI-based background remover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
+__pycache__/
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This site loads Google Tag Manager (container `GTM-NFJTSQ3N`) on every page so v
 
 ## Additional Tools
 
-Alongside the image converter, the site offers several marketing utilities like a Google Ads RSA previewer, a campaign structure visualizer (now with PNG/PDF export), and a **Bulk Match Type Editor** for quickly converting keyword lists to phrase and exact match formats. Enter keywords once and the tool shows both match types side by side with options to copy individual or all results. A simple **Background Remover** uses MediaPipe Selfie Segmentation to strip backgrounds from PNG or JPG files directly in the browser.
+Alongside the image converter, the site offers several marketing utilities like a Google Ads RSA previewer, a campaign structure visualizer (now with PNG/PDF export), and a **Bulk Match Type Editor** for quickly converting keyword lists to phrase and exact match formats. Enter keywords once and the tool shows both match types side by side with options to copy individual or all results. A simple **Background Remover** is also included. It now uses a lightweight FastAPI service with the `transparent-background` library for high‑quality cutouts instead of browser‑based MediaPipe processing.
 
 Every tool page includes a short "About" section and FAQs so you know when to use it and how it works.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import Response
+from transparent_background import Remover
+from PIL import Image
+import io
+
+app = FastAPI()
+remover = Remover(mode='fast', resize='dynamic')
+
+@app.post("/api/remove-background")
+async def remove_background_endpoint(file: UploadFile = File(...)):
+    image_bytes = await file.read()
+    img = Image.open(io.BytesIO(image_bytes)).convert('RGB')
+    out_img = remover.process(img, type='rgba')
+    buf = io.BytesIO()
+    out_img.save(buf, format='PNG')
+    return Response(content=buf.getvalue(), media_type='image/png')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+transparent-background
+pillow

--- a/background-remover.html
+++ b/background-remover.html
@@ -12,8 +12,6 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <!-- MediaPipe Selfie Segmentation -->
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation@0.1/selfie_segmentation.js"></script>
   <script type="module" src="theme.js"></script>
   <script type="module" src="layout.js"></script>
   <script type="module" src="background-remover.js"></script>
@@ -77,7 +75,7 @@
 
         <section class="mt-8 space-y-4">
           <h2 class="text-2xl font-bold" style="color:var(--foreground);">About this tool</h2>
-          <p style="color:var(--foreground);">This demo uses MediaPipe Selfie Segmentation to estimate the subject and make the rest transparent. Complex backgrounds may leave artifacts.</p>
+          <p style="color:var(--foreground);">Images are sent to a small FastAPI service that uses the InSPyReNet-based <code>transparent-background</code> library for high quality cutouts.</p>
           <p style="color:var(--foreground);">For unsupported formats, first convert your image using the <a href="image-converter.html" class="underline text-[var(--primary)]">image converter</a>.</p>
         </section>
       </div>

--- a/background-remover.js
+++ b/background-remover.js
@@ -1,47 +1,12 @@
 import { showNotification } from './utils.js';
 
-let segmenter;
-
-async function loadModel() {
-  if (!segmenter) {
-    segmenter = new SelfieSegmentation({
-      locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation@0.1/${file}`,
-    });
-    segmenter.setOptions({ modelSelection: 1 });
-    await segmenter.initialize();
-  }
-  return segmenter;
-}
-
-async function runSegmentation(image) {
-  await loadModel();
-  return new Promise((resolve, reject) => {
-    segmenter.onResults((results) => resolve(results.segmentationMask));
-    segmenter.send({ image }).catch(reject);
-  });
-}
-
 async function processImage(file) {
-  const img = new Image();
-  img.src = URL.createObjectURL(file);
-  await img.decode();
-
-  const mask = await runSegmentation(img);
-
-  const canvas = document.createElement('canvas');
-  canvas.width = img.naturalWidth;
-  canvas.height = img.naturalHeight;
-  const ctx = canvas.getContext('2d');
-  ctx.drawImage(img, 0, 0);
-
-  ctx.globalCompositeOperation = 'destination-in';
-  ctx.filter = 'blur(2px)';
-  ctx.drawImage(mask, 0, 0, canvas.width, canvas.height);
-  ctx.filter = 'none';
-  ctx.globalCompositeOperation = 'source-over';
-
-  URL.revokeObjectURL(img.src);
-  return canvas.toDataURL('image/png');
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch('/api/remove-background', { method: 'POST', body: formData });
+  if (!res.ok) throw new Error('Server error');
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- add new backend with FastAPI route using transparent-background
- switch background remover JS to use HTTP API
- update HTML page & description
- update README to document new backend
- ignore pycache files

## Testing
- `python -m py_compile backend/main.py`
- `pip install --user -r backend/requirements.txt` *(failed: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6884dfbf65848333bc66b563f99625b6