### PR TITLE
Add headline analyzer tool

### DIFF
--- a/bulk-match-editor.html
+++ b/bulk-match-editor.html
@@ -58,6 +58,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="headline-analyzer.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Headline Analyzer</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/campaign-structure.html
+++ b/campaign-structure.html
@@ -62,6 +62,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="headline-analyzer.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Headline Analyzer</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/google-ads-rsa-preview.html
+++ b/google-ads-rsa-preview.html
@@ -689,6 +689,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="headline-analyzer.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Headline Analyzer</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/headline-analyzer.html
+++ b/headline-analyzer.html
@@ -6,19 +6,17 @@
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Background Remover</title>
+  <title>Headline Analyzer</title>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <!-- MediaPipe Selfie Segmentation -->
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation@0.1/selfie_segmentation.js"></script>
   <script type="module" src="theme.js"></script>
   <script type="module" src="layout.js"></script>
-  <script type="module" src="background-remover.js"></script>
+  <script type="module" src="headline-analyzer.js"></script>
 </head>
-<body data-slug="background-remover" class="bg-transparent min-h-screen flex flex-col">
+<body data-slug="headline-analyzer" class="bg-transparent min-h-screen flex flex-col">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
@@ -70,16 +68,17 @@
 
     <main id="main-content" class="flex-grow p-4">
       <div class="max-w-2xl mx-auto space-y-4">
-        <h1 class="text-3xl font-bold" style="color:var(--foreground);">Background Remover</h1>
-        <p style="color:var(--foreground);">Upload a PNG or JPG image to remove its background. The result will be a transparent PNG.</p>
-        <input id="image-input" type="file" accept="image/png,image/jpeg" class="shad-input" />
-        <img id="result-preview" class="mt-4 max-w-full rounded" alt="Result preview" />
-        <a id="download-btn" href="#" download="background.png" class="download-btn mt-2" style="display:none;">Download PNG</a>
+        <h1 class="text-3xl font-bold" style="color:var(--foreground);">Headline Analyzer</h1>
+        <p style="color:var(--foreground);">Evaluate your headline for word balance, readability and SEO friendliness.</p>
+        <input id="headline-input" type="text" class="shad-input" placeholder="Enter headline" />
+        <input id="industry-input" type="text" class="shad-input" placeholder="Industry (optional)" />
+        <input id="seo-input" type="text" class="shad-input" placeholder="SEO keywords (comma separated)" />
+        <button id="analyze-btn" class="shad-btn">Analyze</button>
+        <div id="analysis-output" class="border rounded p-4 space-y-2"></div>
 
         <section class="mt-8 space-y-4">
           <h2 class="text-2xl font-bold" style="color:var(--foreground);">About this tool</h2>
-          <p style="color:var(--foreground);">This demo uses MediaPipe Selfie Segmentation to estimate the subject and make the rest transparent. Complex backgrounds may leave artifacts.</p>
-          <p style="color:var(--foreground);">For unsupported formats, first convert your image using the <a href="image-converter.html" class="underline text-[var(--primary)]">image converter</a>.</p>
+          <p style="color:var(--foreground);">Use this headline analyzer to craft compelling titles for articles, ads or social posts. It scores your headline and suggests improvements based on readability, word choice and keyword usage. All processing happens locally in your browser.</p>
         </section>
       </div>
     </main>

--- a/headline-analyzer.js
+++ b/headline-analyzer.js
@@ -1,0 +1,100 @@
+import { showNotification } from './utils.js';
+
+const commonWords = [
+  'the','be','to','of','and','a','in','that','have','i','it','for','not','on','with','he','as','you','do','at','this','but','his','by','from','they','we','say','her','she','or','an'
+];
+
+const powerWords = [
+  'ultimate','guaranteed','powerful','proven','easy','quick','boost','free','best','top','secret','unlock','discover','new','save','win','exclusive'
+];
+
+const emotionalWords = [
+  'amazing','exciting','shocking','surprising','incredible','heartwarming','love','fear','hate','happy','sad','thrilling','epic','unbelievable','awesome'
+];
+
+function countSyllables(word) {
+  word = word.toLowerCase();
+  if (word.length <= 3) return 1;
+  word = word.replace(/(?:[^laeiouy]es|ed|[^laeiouy]e)$/,'');
+  word = word.replace(/^y/,'');
+  const matches = word.match(/[aeiouy]{1,2}/g);
+  return matches ? matches.length : 1;
+}
+
+function analyzeHeadline(text, keywords) {
+  const words = text.toLowerCase().match(/\b[a-z']+\b/g) || [];
+  const total = words.length || 1;
+  const sentences = text.split(/[.!?]+/).filter(s => s.trim().length > 0).length || 1;
+  const syllables = words.reduce((acc,w)=>acc+countSyllables(w),0);
+  const readingEase = 206.835 - 1.015*(total/sentences) - 84.6*(syllables/total);
+
+  const counts = {
+    power: 0,
+    emotional: 0,
+    common: 0
+  };
+  words.forEach(w => {
+    if (powerWords.includes(w)) counts.power++;
+    else if (emotionalWords.includes(w)) counts.emotional++;
+    else if (commonWords.includes(w)) counts.common++;
+  });
+  const uncommon = total - counts.power - counts.emotional - counts.common;
+
+  const matches = keywords.filter(k => text.toLowerCase().includes(k.toLowerCase()));
+
+  const lengthScore = Math.max(0, 20 - Math.abs(total - 8) * 2);
+  const readabilityScore = Math.max(0, Math.min(20, (readingEase/100) * 20));
+  const seoScore = keywords.length ? (matches.length / keywords.length) * 20 : 10;
+  const powerScore = Math.min(counts.power * 5, 15);
+  const emotionalScore = Math.min(counts.emotional * 4, 15);
+  const balanceScore = Math.max(0, Math.min(10, (uncommon/total) * 10));
+
+  const score = Math.round(lengthScore + readabilityScore + seoScore + powerScore + emotionalScore + balanceScore);
+
+  const suggestions = [];
+  if (total < 6) suggestions.push('Consider making the headline longer for clarity.');
+  if (total > 12) suggestions.push('Try shortening the headline to keep it concise.');
+  if (readingEase < 60) suggestions.push('Simplify wording to improve readability.');
+  if (keywords.length && matches.length < keywords.length) suggestions.push('Include missing keyword(s): ' + keywords.filter(k=>!matches.includes(k)).join(', '));
+  if (counts.power === 0) suggestions.push('Add power words like "ultimate" or "proven".');
+  if (counts.emotional === 0) suggestions.push('Use emotional language to engage readers.');
+
+  return {
+    score,
+    counts: { ...counts, uncommon },
+    total,
+    readingEase: readingEase.toFixed(1),
+    matches,
+    suggestions
+  };
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const headlineInput = document.getElementById('headline-input');
+  const seoInput = document.getElementById('seo-input');
+  const analyzeBtn = document.getElementById('analyze-btn');
+  const output = document.getElementById('analysis-output');
+
+  if (!headlineInput || !analyzeBtn || !output) return;
+
+  analyzeBtn.addEventListener('click', () => {
+    const headline = headlineInput.value.trim();
+    if (!headline) {
+      showNotification('Please enter a headline', 'error');
+      return;
+    }
+    const keywords = seoInput.value.split(',').map(k => k.trim()).filter(Boolean);
+    const result = analyzeHeadline(headline, keywords);
+    output.innerHTML = `
+      <p><strong>Score:</strong> ${result.score}/100</p>
+      <p><strong>Word count:</strong> ${result.total}</p>
+      <p><strong>Reading ease:</strong> ${result.readingEase}</p>
+      <p><strong>Power words:</strong> ${result.counts.power}</p>
+      <p><strong>Emotional words:</strong> ${result.counts.emotional}</p>
+      <p><strong>Uncommon words:</strong> ${result.counts.uncommon}</p>
+      <p><strong>SEO keywords included:</strong> ${result.matches.join(', ') || 'None'}</p>
+      <h3 class="font-semibold mt-2">Suggestions</h3>
+      <ul class="list-disc ml-6">${result.suggestions.map(s=>`<li>${s}</li>`).join('') || '<li>No suggestions</li>'}</ul>
+    `;
+  });
+});

--- a/image-converter.html
+++ b/image-converter.html
@@ -84,6 +84,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="headline-analyzer.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Headline Analyzer</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="headline-analyzer.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Headline Analyzer</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">
@@ -113,6 +114,10 @@
         <a href="json-formatter.html" class="tool-card border rounded p-4" data-name="JSON Formatter" data-category="Utilities" data-slug="json-formatter">
           <h3 class="font-semibold mb-1" style="color:var(--foreground);">JSON Formatter</h3>
           <p class="text-sm" style="color:var(--foreground);">Format or minify JSON easily.</p>
+        </a>
+        <a href="headline-analyzer.html" class="tool-card border rounded p-4" data-name="Headline Analyzer" data-category="Writing" data-slug="headline-analyzer">
+          <h3 class="font-semibold mb-1" style="color:var(--foreground);">Headline Analyzer</h3>
+          <p class="text-sm" style="color:var(--foreground);">Rate and improve your headlines.</p>
         </a>
       </div>
       </div>

--- a/json-formatter.html
+++ b/json-formatter.html
@@ -60,6 +60,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="headline-analyzer.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Headline Analyzer</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/request-tool.html
+++ b/request-tool.html
@@ -59,6 +59,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="headline-analyzer.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Headline Analyzer</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">


### PR DESCRIPTION
## Summary
- implement new headline analyzer tool
- insert headline analyzer navigation links
- add headline analyzer to homepage tool grid

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6884ee153c648333859afaf54a5eb547