### PR TITLE
Add Base64 encoder/decoder tool

### DIFF
--- a/background-remover.html
+++ b/background-remover.html
@@ -60,6 +60,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="base64.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Base64 Encoder</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/base64.html
+++ b/base64.html
@@ -6,7 +6,7 @@
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Request a Tool</title>
+  <title>Base64 Encoder/Decoder</title>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -14,16 +14,15 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <script type="module" src="theme.js"></script>
   <script type="module" src="layout.js"></script>
+  <script type="module" src="base64.js"></script>
 </head>
-<body data-slug="request-tool" class="bg-transparent min-h-screen flex flex-col">
+<body data-slug="base64" class="bg-transparent min-h-screen flex flex-col">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
-  <!-- Navigation Bar -->
   <nav class="bg-[var(--background)] shadow-md border-b border-[var(--foreground)]/30">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
-        <!-- Logo and site name -->
         <div class="flex items-center gap-4">
           <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
             <i class="fas fa-bars"></i>
@@ -40,7 +39,7 @@
       </div>
     </div>
   </nav>
-  <!-- Page Layout -->
+
   <div class="flex flex-grow">
     <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-30"></div>
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
@@ -66,25 +65,25 @@
         <a href="request-tool.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Request a Tool</a>
       </div>
     </aside>
+
     <main id="main-content" class="flex-grow p-4">
-      <div class="max-w-xl mx-auto">
-        <h1 class="text-3xl font-bold mb-4" style="color:var(--foreground);">Request a Tool</h1>
-        <p style="color:var(--foreground);">Let us know what tool you'd like us to build next.</p>
-        <div id="request-tool-embed" class="my-8">
-          <!-- loops.so embed code will be inserted here -->
+      <div class="max-w-2xl mx-auto space-y-4">
+        <h1 class="text-3xl font-bold" style="color:var(--foreground);">Base64 Encoder/Decoder</h1>
+        <p style="color:var(--foreground);">Paste text or select a file to encode as Base64. You can also decode Base64 strings back to text or files.</p>
+        <textarea id="input" rows="6" class="shad-input" placeholder="Input text or Base64"></textarea>
+        <input id="file-input" type="file" class="shad-input mt-2" />
+        <div class="flex gap-2 mt-2">
+          <button id="encode-btn" class="shad-btn">Encode</button>
+          <button id="decode-btn" class="shad-btn">Decode</button>
         </div>
-        <section class="space-y-4">
-          <h2 class="text-2xl font-bold" style="color:var(--foreground);">About this page</h2>
-          <p style="color:var(--foreground);">Use this form to suggest new utilities that would help your marketing workflow. We review submissions regularly.</p>
-          <h3 class="text-xl font-semibold" style="color:var(--foreground);">FAQs</h3>
-          <details class="border p-2 rounded">
-            <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">How soon will my idea be built?</summary>
-            <p class="mt-2" style="color:var(--foreground);">Ideas with the most interest get prioritised, but we can't guarantee timelines.</p>
-          </details>
-          <details class="border p-2 rounded">
-            <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Will you notify me?</summary>
-            <p class="mt-2" style="color:var(--foreground);">Leave your email in the request and we'll let you know if we develop your suggestion.</p>
-          </details>
+        <textarea id="output" rows="6" class="shad-input" placeholder="Output" readonly></textarea>
+        <div class="flex gap-2 mt-2">
+          <button id="copy-btn" class="shad-btn">Copy</button>
+          <button id="download-btn" class="shad-btn">Download</button>
+        </div>
+        <section class="mt-8 space-y-4">
+          <h2 class="text-2xl font-bold" style="color:var(--foreground);">About this tool</h2>
+          <p style="color:var(--foreground);">Use it to quickly convert text or small files to and from Base64 without uploading anything.</p>
         </section>
       </div>
     </main>
@@ -97,6 +96,5 @@
       </div>
     </div>
   </footer>
-  <!-- layout.js handles sidebar functionality -->
 </body>
 </html>

--- a/base64.js
+++ b/base64.js
@@ -1,0 +1,89 @@
+import { showNotification } from './utils.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('input');
+  const fileInput = document.getElementById('file-input');
+  const encodeBtn = document.getElementById('encode-btn');
+  const decodeBtn = document.getElementById('decode-btn');
+  const output = document.getElementById('output');
+  const copyBtn = document.getElementById('copy-btn');
+  const downloadBtn = document.getElementById('download-btn');
+
+  let outputBlob = null;
+  let outputName = 'output';
+
+  async function encode() {
+    try {
+      let text;
+      if (fileInput.files.length > 0) {
+        const file = fileInput.files[0];
+        const buf = await file.arrayBuffer();
+        const binary = String.fromCharCode(...new Uint8Array(buf));
+        text = btoa(binary);
+        outputName = file.name + '.b64';
+      } else {
+        text = btoa(unescape(encodeURIComponent(input.value)));
+        outputName = 'text.b64';
+      }
+      output.value = text;
+      outputBlob = new Blob([text], { type: 'text/plain' });
+    } catch (err) {
+      showNotification('Failed to encode', 'error');
+    }
+  }
+
+  async function decode() {
+    try {
+      let base64;
+      if (fileInput.files.length > 0) {
+        base64 = await fileInput.files[0].text();
+        outputName = fileInput.files[0].name.replace(/\.b64$/, '') || 'output';
+      } else {
+        base64 = input.value.trim();
+        outputName = 'output';
+      }
+      const binary = atob(base64);
+      const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+      outputBlob = new Blob([bytes]);
+      let text;
+      try {
+        text = new TextDecoder().decode(bytes);
+      } catch {
+        text = null;
+      }
+      if (text && /[\x09-\x0d\x20-\x7e]/.test(text)) {
+        output.value = text;
+      } else {
+        output.value = '[binary data]';
+      }
+    } catch (err) {
+      showNotification('Invalid Base64 input', 'error');
+      outputBlob = null;
+      output.value = '';
+    }
+  }
+
+  if (encodeBtn) encodeBtn.addEventListener('click', encode);
+  if (decodeBtn) decodeBtn.addEventListener('click', decode);
+
+  if (copyBtn) {
+    copyBtn.addEventListener('click', () => {
+      if (!output.value) return;
+      navigator.clipboard.writeText(output.value).then(() => {
+        showNotification('Copied to clipboard', 'success');
+      });
+    });
+  }
+
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', () => {
+      if (!outputBlob) return;
+      const url = URL.createObjectURL(outputBlob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = outputName;
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  }
+});

--- a/bulk-match-editor.html
+++ b/bulk-match-editor.html
@@ -58,6 +58,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="base64.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Base64 Encoder</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/campaign-structure.html
+++ b/campaign-structure.html
@@ -62,6 +62,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="base64.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Base64 Encoder</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/google-ads-rsa-preview.html
+++ b/google-ads-rsa-preview.html
@@ -689,6 +689,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="base64.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Base64 Encoder</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/image-converter.html
+++ b/image-converter.html
@@ -84,6 +84,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="base64.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Base64 Encoder</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="base64.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Base64 Encoder</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">
@@ -113,6 +114,10 @@
         <a href="json-formatter.html" class="tool-card border rounded p-4" data-name="JSON Formatter" data-category="Utilities" data-slug="json-formatter">
           <h3 class="font-semibold mb-1" style="color:var(--foreground);">JSON Formatter</h3>
           <p class="text-sm" style="color:var(--foreground);">Format or minify JSON easily.</p>
+        </a>
+        <a href="base64.html" class="tool-card border rounded p-4" data-name="Base64 Encoder" data-category="Utilities" data-slug="base64">
+          <h3 class="font-semibold mb-1" style="color:var(--foreground);">Base64 Encoder</h3>
+          <p class="text-sm" style="color:var(--foreground);">Encode or decode Base64 strings.</p>
         </a>
       </div>
       </div>

--- a/json-formatter.html
+++ b/json-formatter.html
@@ -60,6 +60,7 @@
         <li><a href="campaign-structure.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Campaign Structure</a></li>
         <li><a href="bulk-match-editor.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Bulk Match Type Editor</a></li>
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
+        <li><a href="base64.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Base64 Encoder</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">


### PR DESCRIPTION
## Summary
- add a simple Base64 encoder/decoder page with text and file support
- implement Base64 logic in `base64.js`
- link new tool from all sidebars and the home page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884ee5f49a48333934c21bda7a213e9