### PR TITLE
Apply homepage nav button styles to other pages

### DIFF
--- a/background-remover.html
+++ b/background-remover.html
@@ -26,7 +26,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -34,7 +34,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -47,7 +47,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/bulk-match-editor.html
+++ b/bulk-match-editor.html
@@ -24,7 +24,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -32,7 +32,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -45,7 +45,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/campaign-structure.html
+++ b/campaign-structure.html
@@ -28,7 +28,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -36,7 +36,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -49,7 +49,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/color-palette.html
+++ b/color-palette.html
@@ -25,7 +25,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -33,7 +33,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -46,7 +46,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/google-ads-rsa-preview.html
+++ b/google-ads-rsa-preview.html
@@ -654,7 +654,7 @@
       <div class="flex justify-between h-16">
         <!-- Logo and site name -->
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -662,7 +662,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -676,7 +676,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/image-converter.html
+++ b/image-converter.html
@@ -39,7 +39,7 @@
       <div class="flex justify-between h-16">
         <!-- Logo and site name -->
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -57,7 +57,7 @@
         </div> -->
         
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -71,7 +71,7 @@
     <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/json-formatter.html
+++ b/json-formatter.html
@@ -26,7 +26,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -34,7 +34,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -47,7 +47,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/pdf-merger.html
+++ b/pdf-merger.html
@@ -28,7 +28,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -36,7 +36,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -48,7 +48,7 @@
     <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/request-tool.html
+++ b/request-tool.html
@@ -26,7 +26,7 @@
       <div class="flex justify-between h-16">
         <!-- Logo and site name -->
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -34,7 +34,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -47,7 +47,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>

--- a/utm-builder.html
+++ b/utm-builder.html
@@ -24,7 +24,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center gap-4">
-          <button id="sidebar-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none">
+          <button id="sidebar-toggle" class="shad-btn p-2" aria-label="Open sidebar">
             <i class="fas fa-bars"></i>
           </button>
           <a href="index.html" class="flex items-center gap-2">
@@ -32,7 +32,7 @@
           </a>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Toggle theme">
+          <button id="theme-toggle" class="shad-btn p-2" aria-label="Toggle theme">
             <span id="theme-toggle-icon">🌙</span>
           </button>
         </div>
@@ -44,7 +44,7 @@
     <aside id="sidebar" class="fixed top-0 left-0 w-64 h-full bg-[var(--background)] border-r border-[var(--foreground)]/20 p-4 transform -translate-x-full transition-transform z-40">
       <div class="flex justify-between items-center mb-4">
         <a href="index.html" class="text-xl font-bold" style="color:var(--foreground);">reformately</a>
-        <button id="sidebar-close" class="text-[var(--foreground)] hover:text-[var(--primary)] focus:outline-none" aria-label="Close sidebar">
+        <button id="sidebar-close" class="shad-btn p-2" aria-label="Close sidebar">
           <i class="fas fa-times"></i>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- use `.shad-btn p-2` style for sidebar open/close and theme toggle across all pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688748083aa08333a07a5e4308d319a2