### PR TITLE
Fix QR code container sizing

### DIFF
--- a/qr-generator.html
+++ b/qr-generator.html
@@ -104,8 +104,8 @@
           </div>
         </div>
         <div class="mt-6 flex justify-center">
-          <div id="qr-container" class="p-2 bg-white" aria-label="QR code" role="img">
-            <canvas id="qr-canvas" width="200" height="200"></canvas>
+          <div id="qr-container" class="p-2 bg-white inline-block" aria-label="QR code" role="img">
+            <canvas id="qr-canvas" width="200" height="200" class="hidden"></canvas>
           </div>
         </div>
         <div class="flex gap-2 justify-center mt-4">

--- a/qr-generator.js
+++ b/qr-generator.js
@@ -52,6 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const ecc = eccSelect.value || 'M';
 
     canvas.width = canvas.height = size;
+    container.style.width = `${size}px`;
+    container.style.height = `${size}px`;
 
     if (!qr) {
       qr = new QRCode(container, {


### PR DESCRIPTION
## Summary
- keep QR preview canvas hidden so it's not rendered twice
- update QR generator JS to size the container dynamically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888259b07ac83339d6f84985094eff9