### PR TITLE
Add PDF OCR tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This site loads Google Tag Manager (container `GTM-NFJTSQ3N`) on every page so v
 
 ## Additional Tools
 
-Alongside the image converter, the site offers several marketing utilities like a Google Ads RSA previewer, a campaign structure visualizer (now with PNG/PDF export), a simple **PDF Merger**, and a **Bulk Match Type Editor** for quickly converting keyword lists to phrase and exact match formats. Enter keywords once and the tool shows both match types side by side with options to copy individual or all results. A simple **Background Remover** uses MediaPipe Selfie Segmentation to strip backgrounds from PNG or JPG files directly in the browser.
+Alongside the image converter, the site offers several marketing utilities like a Google Ads RSA previewer, a campaign structure visualizer (now with PNG/PDF export), a simple **PDF Merger**, and a **Bulk Match Type Editor** for quickly converting keyword lists to phrase and exact match formats. Enter keywords once and the tool shows both match types side by side with options to copy individual or all results. A simple **Background Remover** uses MediaPipe Selfie Segmentation to strip backgrounds from PNG or JPG files directly in the browser. A **PDF OCR** tool lets you extract text from PDFs directly in your browser.
 
 Every tool page includes a short "About" section and FAQs so you know when to use it and how it works.
 

--- a/background-remover.html
+++ b/background-remover.html
@@ -62,6 +62,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/bulk-match-editor.html
+++ b/bulk-match-editor.html
@@ -60,6 +60,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/campaign-structure.html
+++ b/campaign-structure.html
@@ -64,6 +64,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/color-palette.html
+++ b/color-palette.html
@@ -61,6 +61,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/google-ads-rsa-preview.html
+++ b/google-ads-rsa-preview.html
@@ -691,6 +691,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/image-converter.html
+++ b/image-converter.html
@@ -86,6 +86,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
         <li><a href="utm-builder.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">UTM Builder</a></li>
         <li><a href="qr-generator.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">QR Code Generator</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">
@@ -133,6 +134,10 @@
         <a href="qr-generator.html" class="tool-card" data-name="QR Code Generator" data-category="Utilities" data-slug="qr-generator">
           <h3 class="font-semibold mb-1" style="color:var(--foreground);">QR Code Generator</h3>
           <p class="text-sm" style="color:var(--foreground);">Create customizable QR codes.</p>
+        </a>
+        <a href="pdf-ocr.html" class="tool-card" data-name="PDF OCR" data-category="Utilities" data-slug="pdf-ocr">
+          <h3 class="font-semibold mb-1" style="color:var(--foreground);">PDF OCR</h3>
+          <p class="text-sm" style="color:var(--foreground);">Extract text from PDFs using OCR.</p>
         </a>
       </div>
       </div>

--- a/json-formatter.html
+++ b/json-formatter.html
@@ -62,6 +62,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/pdf-merger.html
+++ b/pdf-merger.html
@@ -63,6 +63,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/pdf-ocr.html
+++ b/pdf-ocr.html
@@ -6,17 +6,19 @@
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>UTM Parameter Builder</title>
+  <title>PDF OCR</title>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');</script>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <script type="module" src="theme.js"></script>
   <script type="module" src="layout.js"></script>
-  <script type="module" src="utm-builder.js"></script>
+  <script type="module" src="pdf-ocr.js"></script>
 </head>
-<body data-slug="utm-builder" class="bg-transparent min-h-screen flex flex-col">
+<body data-slug="pdf-ocr" class="bg-transparent min-h-screen flex flex-col">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NFJTSQ3N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
@@ -60,6 +62,7 @@
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
         <li><a href="utm-builder.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">UTM Builder</a></li>
+        <li><a href="qr-generator.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">QR Code Generator</a></li>
         <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
@@ -68,44 +71,31 @@
       </div>
     </aside>
     <main id="main-content" class="flex-grow p-4">
-      <div class="max-w-xl mx-auto">
-        <h1 class="text-3xl font-bold mb-2" style="color:var(--foreground);">UTM Parameter Builder</h1>
-        <p class="mb-4" style="color:var(--foreground);">Generate tracking URLs for your marketing campaigns.</p>
-        <div class="space-y-4">
-          <label class="block" style="color:var(--foreground);">Base URL
-            <input id="base-url" type="text" class="shad-input mt-1" placeholder="https://example.com/page" />
-          </label>
-          <label class="block" style="color:var(--foreground);">Source
-            <input id="utm-source" type="text" class="shad-input mt-1" placeholder="newsletter" />
-          </label>
-          <label class="block" style="color:var(--foreground);">Medium
-            <input id="utm-medium" type="text" class="shad-input mt-1" placeholder="email" />
-          </label>
-          <label class="block" style="color:var(--foreground);">Campaign
-            <input id="utm-campaign" type="text" class="shad-input mt-1" placeholder="spring_sale" />
-          </label>
-          <label class="block" style="color:var(--foreground);">Term
-            <input id="utm-term" type="text" class="shad-input mt-1" placeholder="optional keyword" />
-          </label>
-          <label class="block" style="color:var(--foreground);">Content
-            <input id="utm-content" type="text" class="shad-input mt-1" placeholder="ad variant" />
-          </label>
-          <label class="block" style="color:var(--foreground);">Tracking URL
-            <input id="utm-result" type="text" class="shad-input mt-1" readonly />
-          </label>
-          <button id="copy-btn" class="shad-btn">Copy URL</button>
+      <div class="max-w-2xl mx-auto space-y-4">
+        <h1 class="text-3xl font-bold" style="color:var(--foreground);">PDF OCR</h1>
+        <p style="color:var(--foreground);">Upload a PDF file to extract its text using OCR. All processing happens in your browser.</p>
+        <div id="drop-area" class="border-2 border-dashed border-[var(--border)] rounded-lg p-6 text-center space-y-2 bg-[var(--card)]">
+          <p class="text-sm" style="color:var(--foreground);">Drag and drop a PDF here</p>
+          <button id="select-btn" class="shad-btn">Select PDF</button>
+          <input id="file-input" type="file" accept="application/pdf" style="display:none;" />
         </div>
-        <section class="space-y-4 mt-8">
+        <div id="progress-status" class="text-center" style="color:var(--foreground);"></div>
+        <div id="progress-bar-container" class="w-full max-w-md mx-auto border rounded-lg p-1 bg-[var(--card)]">
+          <div id="progress-bar"></div>
+        </div>
+        <textarea id="text-output" rows="8" class="shad-input font-mono" placeholder="OCR result will appear here"></textarea>
+        <button id="download-btn" class="shad-btn" style="display:none;">Download Text</button>
+        <section class="mt-8 space-y-4">
           <h2 class="text-2xl font-bold" style="color:var(--foreground);">About this tool</h2>
-          <p style="color:var(--foreground);">Use this builder to append UTM parameters to your links so you can track campaign performance in analytics platforms.</p>
+          <p style="color:var(--foreground);">Extract text from scanned or image-based PDFs entirely offline.</p>
           <h3 class="text-xl font-semibold" style="color:var(--foreground);">FAQs</h3>
-          <details class="border p-2 rounded">
-            <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">What are UTM parameters?</summary>
-            <p class="mt-2" style="color:var(--foreground);">They are tags added to a URL that help identify where visitors come from when they land on your site.</p>
+          <details class="border p-4 rounded-lg bg-[var(--card)]">
+            <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Does it work with scanned PDFs?</summary>
+            <p class="mt-2" style="color:var(--foreground);">Yes. Each page is converted to an image and processed with OCR.</p>
           </details>
-          <details class="border p-2 rounded">
-            <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Do you store my links?</summary>
-            <p class="mt-2" style="color:var(--foreground);">No. Everything runs locally in your browser.</p>
+          <details class="border p-4 rounded-lg bg-[var(--card)]">
+            <summary class="cursor-pointer font-semibold" style="color:var(--foreground);">Is my PDF uploaded anywhere?</summary>
+            <p class="mt-2" style="color:var(--foreground);">No. Everything runs locally in your browser so your files remain private.</p>
           </details>
         </section>
       </div>

--- a/pdf-ocr.js
+++ b/pdf-ocr.js
@@ -1,0 +1,88 @@
+import { showNotification } from './utils.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const dropArea = document.getElementById('drop-area');
+  const fileInput = document.getElementById('file-input');
+  const selectBtn = document.getElementById('select-btn');
+  const output = document.getElementById('text-output');
+  const progressStatus = document.getElementById('progress-status');
+  const progressContainer = document.getElementById('progress-bar-container');
+  const progressBar = document.getElementById('progress-bar');
+  const downloadBtn = document.getElementById('download-btn');
+
+  function dragOver(e) {
+    e.preventDefault();
+    dropArea.classList.add('border-blue-300');
+  }
+
+  function dragLeave() {
+    dropArea.classList.remove('border-blue-300');
+  }
+
+  async function processFile(file) {
+    if (!file) return;
+    if (!(file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf'))) {
+      showNotification('Please upload a PDF file', 'error');
+      return;
+    }
+    output.value = '';
+    progressStatus.textContent = 'Loading PDF...';
+    progressContainer.style.display = 'block';
+    progressBar.style.width = '0%';
+    downloadBtn.style.display = 'none';
+
+    try {
+      const buffer = await file.arrayBuffer();
+      const pdf = await pdfjsLib.getDocument({ data: buffer }).promise;
+      const total = Math.min(pdf.numPages, 50);
+      let text = '';
+      for (let i = 1; i <= total; i++) {
+        progressStatus.textContent = `Processing page ${i} of ${total}`;
+        const page = await pdf.getPage(i);
+        const viewport = page.getViewport({ scale: 2 });
+        const canvas = document.createElement('canvas');
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        const ctx = canvas.getContext('2d');
+        await page.render({ canvasContext: ctx, viewport }).promise;
+        const result = await Tesseract.recognize(canvas, 'eng');
+        text += result.data.text + '\n\n';
+        progressBar.style.width = `${Math.round((i / total) * 100)}%`;
+        await new Promise(r => setTimeout(r));
+      }
+      output.value = text.trim();
+      progressStatus.textContent = 'Done!';
+      progressContainer.style.display = 'none';
+      downloadBtn.style.display = 'inline-block';
+      downloadBtn.onclick = () => {
+        const blob = new Blob([output.value], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = file.name.replace(/\.pdf$/i, '') + '.txt';
+        a.click();
+        URL.revokeObjectURL(url);
+      };
+    } catch (err) {
+      console.error(err);
+      progressContainer.style.display = 'none';
+      progressStatus.textContent = '';
+      showNotification('OCR failed: ' + err.message, 'error');
+    }
+  }
+
+  dropArea.addEventListener('dragover', dragOver);
+  dropArea.addEventListener('dragleave', dragLeave);
+  dropArea.addEventListener('drop', e => {
+    e.preventDefault();
+    dragLeave();
+    processFile(e.dataTransfer.files[0]);
+  });
+
+  fileInput.addEventListener('change', () => {
+    processFile(fileInput.files[0]);
+    fileInput.value = '';
+  });
+
+  if (selectBtn) selectBtn.addEventListener('click', () => fileInput.click());
+});

--- a/qr-generator.html
+++ b/qr-generator.html
@@ -63,6 +63,7 @@
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
         <li><a href="utm-builder.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">UTM Builder</a></li>
         <li><a href="qr-generator.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">QR Code Generator</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">

--- a/request-tool.html
+++ b/request-tool.html
@@ -62,6 +62,7 @@
         <li><a href="json-formatter.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">JSON Formatter</a></li>
         <li><a href="color-palette.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">Colour Palette Extractor</a></li>
         <li><a href="pdf-merger.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF Merger</a></li>
+        <li><a href="pdf-ocr.html" class="text-[var(--foreground)] hover:text-[var(--primary)]">PDF OCR</a></li>
         <li><a href="#" class="text-[var(--foreground)] hover:text-[var(--primary)]">More coming soon</a></li>
       </ul>
       <div class="mt-6 pt-6 border-t border-[var(--foreground)]/20">


### PR DESCRIPTION
## Summary
- add new browser-based PDF OCR tool
- link PDF OCR from the sidebar and home page
- note PDF OCR capability in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888302f7aec8333a20747550eadeb30