### PR TITLE
Add simple layout tool prototype

### DIFF
--- a/__tests__/layout-export.test.js
+++ b/__tests__/layout-export.test.js
@@ -1,0 +1,17 @@
+const { canvasToPng, canvasToPdf } = require('../layout-export.js');
+
+const SAMPLE_PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4/5/hPwAHggJ/P+ZtAAAAAElFTkSuQmCC';
+
+describe('layout export', () => {
+  test('exports canvas to PNG data URL', () => {
+    const canvas = { width: 1, height: 1, toDataURL: () => SAMPLE_PNG };
+    const url = canvasToPng(canvas);
+    expect(url.startsWith('data:image/png')).toBe(true);
+  });
+
+  test('exports canvas to PDF bytes', async () => {
+    const canvas = { width: 1, height: 1, toDataURL: () => SAMPLE_PNG };
+    const bytes = await canvasToPdf(canvas);
+    expect(bytes instanceof Uint8Array).toBe(true);
+  });
+});

--- a/layout-export.js
+++ b/layout-export.js
@@ -1,0 +1,17 @@
+const { PDFDocument } = require('pdf-lib');
+
+function canvasToPng(canvas) {
+  return canvas.toDataURL('image/png');
+}
+
+async function canvasToPdf(canvas) {
+  const pdf = await PDFDocument.create();
+  const pngData = canvas.toDataURL('image/png');
+  const pngBytes = Uint8Array.from(atob(pngData.split(',')[1]), c => c.charCodeAt(0));
+  const img = await pdf.embedPng(pngBytes);
+  const page = pdf.addPage([canvas.width, canvas.height]);
+  page.drawImage(img, { x: 0, y: 0, width: canvas.width, height: canvas.height });
+  return pdf.save();
+}
+
+module.exports = { canvasToPng, canvasToPdf };

--- a/layout-tool.html
+++ b/layout-tool.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Layout Tool</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="layout-tool.js"></script>
+</head>
+<body class="p-4">
+  <div class="space-y-2 mb-4">
+    <select id="preset-select" class="shad-input"></select>
+    <button id="add-text" class="shad-btn">Add Text</button>
+    <input type="file" id="img-input" accept="image/*" class="hidden" />
+    <button id="add-image" class="shad-btn">Add Image</button>
+    <button id="export-png" class="shad-btn">Export PNG</button>
+    <button id="export-pdf" class="shad-btn">Export PDF</button>
+  </div>
+  <div id="canvas-container" class="relative border bg-white" style="width:600px;height:800px">
+    <canvas id="canvas" width="600" height="800" class="border"></canvas>
+  </div>
+</body>
+</html>

--- a/layout-tool.js
+++ b/layout-tool.js
@@ -1,0 +1,106 @@
+import { canvasToPng, canvasToPdf } from './layout-export.js';
+
+async function loadPresets() {
+  const res = await fetch('presets.json');
+  return res.json();
+}
+
+function mmToPx(mm, dpi) {
+  return Math.round((mm / 25.4) * dpi);
+}
+
+function createTextObject(ctx, text, x, y) {
+  return { type: 'text', text, x, y, font: '20px sans-serif' };
+}
+
+function createImageObject(img, x, y, w, h) {
+  return { type: 'image', img, x, y, w, h };
+}
+
+function render(canvas, objects) {
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  for (const obj of objects) {
+    if (obj.type === 'text') {
+      ctx.font = obj.font;
+      ctx.fillText(obj.text, obj.x, obj.y);
+    } else if (obj.type === 'image') {
+      ctx.drawImage(obj.img, obj.x, obj.y, obj.w, obj.h);
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const presetSel = document.getElementById('preset-select');
+  const addTextBtn = document.getElementById('add-text');
+  const addImgBtn = document.getElementById('add-image');
+  const imgInput = document.getElementById('img-input');
+  const exportPngBtn = document.getElementById('export-png');
+  const exportPdfBtn = document.getElementById('export-pdf');
+  const canvas = document.getElementById('canvas');
+  const container = document.getElementById('canvas-container');
+
+  const presets = await loadPresets();
+  presets.forEach((p,i) => {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = p.name;
+    presetSel.appendChild(opt);
+  });
+
+  let objects = [];
+
+  function applyPreset(p) {
+    const dpi = p.dpi || 72;
+    const width = p.units === 'mm' ? mmToPx(p.width, dpi) : p.width;
+    const height = p.units === 'mm' ? mmToPx(p.height, dpi) : p.height;
+    canvas.width = width;
+    canvas.height = height;
+    container.style.width = width + 'px';
+    container.style.height = height + 'px';
+    render(canvas, objects);
+  }
+
+  presetSel.addEventListener('change', () => {
+    applyPreset(presets[presetSel.value]);
+  });
+
+  applyPreset(presets[0]);
+
+  addTextBtn.addEventListener('click', () => {
+    const text = prompt('Enter text');
+    if (!text) return;
+    objects.push(createTextObject(canvas.getContext('2d'), text, 50, 50));
+    render(canvas, objects);
+  });
+
+  addImgBtn.addEventListener('click', () => imgInput.click());
+
+  imgInput.addEventListener('change', () => {
+    const file = imgInput.files[0];
+    if (!file) return;
+    const img = new Image();
+    img.onload = () => {
+      objects.push(createImageObject(img, 50, 100, img.width, img.height));
+      render(canvas, objects);
+    };
+    img.src = URL.createObjectURL(file);
+    imgInput.value = '';
+  });
+
+  exportPngBtn.addEventListener('click', () => {
+    const link = document.createElement('a');
+    link.href = canvasToPng(canvas);
+    link.download = 'design.png';
+    link.click();
+  });
+
+  exportPdfBtn.addEventListener('click', async () => {
+    const bytes = await canvasToPdf(canvas);
+    const blob = new Blob([bytes], { type: 'application/pdf' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'design.pdf';
+    link.click();
+  });
+});

--- a/presets.json
+++ b/presets.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Poster A4",
+    "width": 210,
+    "height": 297,
+    "units": "mm",
+    "dpi": 300,
+    "bleed": 3
+  },
+  {
+    "name": "Instagram Square",
+    "width": 1080,
+    "height": 1080,
+    "units": "px",
+    "dpi": 72,
+    "bleed": 0
+  }
+]


### PR DESCRIPTION
## Summary
- implement a basic layout tool page with presets
- allow adding text or images and export canvas to PNG or PDF
- provide simple export utilities and accompanying unit tests
- include a small preset library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68884ad286c8833389ffdfabcfabd057