### PR TITLE
Improve sidebar behavior

### DIFF
--- a/layout.js
+++ b/layout.js
@@ -11,16 +11,17 @@ document.addEventListener('DOMContentLoaded', () => {
   function openSidebar() {
     sidebar.classList.remove('-translate-x-full');
     if (sidebarOverlay) sidebarOverlay.classList.remove('hidden');
+    document.body.style.overflow = 'hidden';
   }
 
   function closeSidebar() {
     sidebar.classList.add('-translate-x-full');
     if (sidebarOverlay) sidebarOverlay.classList.add('hidden');
+    document.body.style.overflow = '';
   }
 
   if (sidebar && sidebarToggle) {
-    // Start closed on all screen sizes for consistent behavior.
-    closeSidebar();
+    // Sidebar starts hidden via CSS for consistent behavior.
 
     sidebarToggle.addEventListener('click', () => {
       const isOpen = !sidebar.classList.contains('-translate-x-full');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -60,7 +60,16 @@
 
 body {
   font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
-  background-color:var(--background) !important; 
+  background-color:var(--background) !important;
+}
+
+/* Sidebar scroll containment and positioning */
+#sidebar {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 label, th, .font-medium, .text-blue-900, .text-gray-500, .text-lg, .text-sm, .text-base, .break-words, .whitespace-normal, .max-w-xs, .max-w-5xl, .text-center, .font-bold {


### PR DESCRIPTION
## Summary
- keep sidebar fixed with overscroll containment
- lock page scrolling when sidebar is open
- ensure sidebar toggle never runs on load

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688d55606fec83338695f2fb977f1ac7