### PR TITLE
feat: add reusable sidebar component

### DIFF
--- a/tools/sidebar/sidebar.css
+++ b/tools/sidebar/sidebar.css
@@ -1,0 +1,14 @@
+/* Optional scrollbar styling for reform-sidebar component */
+reform-sidebar::part(container) {
+  scrollbar-width: thin;
+  scrollbar-color: #52525b transparent;
+}
+
+reform-sidebar::part(container)::-webkit-scrollbar {
+  width: 8px;
+}
+
+reform-sidebar::part(container)::-webkit-scrollbar-thumb {
+  background-color: #52525b;
+  border-radius: 4px;
+}

--- a/tools/sidebar/sidebar.js
+++ b/tools/sidebar/sidebar.js
@@ -1,0 +1,93 @@
+let toolsPromise;
+
+/**
+ * Fetches the tools manifest with caching.
+ * @returns {Promise<Array<{id:string,label:string,href:string}>>} Resolves to the list of tools.
+ */
+export function fetchTools() {
+  const CACHE_KEY = 'reform-tools';
+  const EXPIRY_KEY = `${CACHE_KEY}-expiry`;
+  const TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+  const now = Date.now();
+
+  const cached = localStorage.getItem(CACHE_KEY);
+  const expiry = Number(localStorage.getItem(EXPIRY_KEY));
+  if (cached && expiry && now < expiry) {
+    try {
+      return Promise.resolve(JSON.parse(cached));
+    } catch (err) {
+      // fall through to fetch
+    }
+  }
+
+  if (!toolsPromise || !expiry || now >= expiry) {
+    toolsPromise = fetch('/tools/tools.json')
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load tools');
+        return res.json();
+      })
+      .then((data) => {
+        try {
+          localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+          localStorage.setItem(EXPIRY_KEY, String(now + TTL_MS));
+        } catch (e) {
+          // ignore storage errors
+        }
+        return data;
+      });
+  }
+  return toolsPromise;
+}
+
+/**
+ * Sidebar navigation component listing available tools.
+ */
+export class ReformSidebar extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.rendered = false;
+  }
+
+  async connectedCallback() {
+    if (this.rendered) return;
+    try {
+      const tools = await fetchTools();
+      this.render(tools);
+      this.rendered = true;
+    } catch (err) {
+      this.remove();
+    }
+  }
+
+  /**
+   * Renders the sidebar links inside the shadow DOM.
+   * @param {Array<{id:string,label:string,href:string}>} tools List of tools to display.
+   * @returns {void}
+   */
+  render(tools) {
+    const nav = document.createElement('nav');
+    nav.setAttribute('aria-label', 'Tool list');
+    nav.setAttribute('part', 'container');
+    nav.className =
+      'w-56 bg-zinc-800 text-white text-sm h-screen overflow-y-auto border-r border-zinc-700 py-4 px-3 space-y-1';
+
+    const current = window.location.pathname.replace(/\/$/, '');
+
+    tools.forEach((tool) => {
+      const a = document.createElement('a');
+      a.href = tool.href;
+      a.textContent = tool.label;
+      a.className = 'block rounded px-2 py-1 hover:bg-zinc-700/50';
+      const linkPath = new URL(tool.href, window.location.origin).pathname.replace(/\/$/, '');
+      if (current === linkPath) {
+        a.classList.add('bg-zinc-700/70', 'font-semibold');
+      }
+      nav.appendChild(a);
+    });
+
+    this.shadowRoot.append(nav);
+  }
+}
+
+customElements.define('reform-sidebar', ReformSidebar);

--- a/tools/tools.json
+++ b/tools/tools.json
@@ -1,0 +1,20 @@
+[
+  { "id": "background-remover", "label": "Background Remover", "href": "/tools/background-remover/" },
+  { "id": "bulk-match-editor", "label": "Bulk Match Editor", "href": "/tools/bulk-match-editor/" },
+  { "id": "campaign-structure", "label": "Campaign Structure", "href": "/tools/campaign-structure/" },
+  { "id": "color-palette", "label": "Color Palette", "href": "/tools/color-palette/" },
+  { "id": "google-ads-rsa-preview", "label": "Google Ads RSA Preview", "href": "/tools/google-ads-rsa-preview/" },
+  { "id": "image-converter", "label": "Image Converter", "href": "/tools/image-converter/" },
+  { "id": "json-formatter", "label": "JSON Formatter", "href": "/tools/json-formatter/" },
+  { "id": "layout-tool", "label": "Layout Tool", "href": "/tools/layout-tool/" },
+  { "id": "meta-tag-generator", "label": "Meta Tag Generator", "href": "/tools/meta-tag-generator/" },
+  { "id": "pdf-merger", "label": "PDF Merger", "href": "/tools/pdf-merger/" },
+  { "id": "pdf-ocr", "label": "PDF OCR", "href": "/tools/pdf-ocr/" },
+  { "id": "qr-generator", "label": "QR Generator", "href": "/tools/qr-generator/" },
+  { "id": "request-tool", "label": "Request Tool", "href": "/tools/request-tool/" },
+  { "id": "robots-txt", "label": "Robots.txt", "href": "/tools/robots-txt/" },
+  { "id": "text-case-converter", "label": "Text Case Converter", "href": "/tools/text-case-converter/" },
+  { "id": "timestamp-converter", "label": "Timestamp Converter", "href": "/tools/timestamp-converter/" },
+  { "id": "utm-builder", "label": "UTM Builder", "href": "/tools/utm-builder/" },
+  { "id": "uuid-generator", "label": "UUID Generator", "href": "/tools/uuid-generator/" }
+]


### PR DESCRIPTION
## Summary
- add `<reform-sidebar>` web component that auto-loads tool manifest with 12h cache and highlights current page
- provide optional scrollbar styling and shared fetch promise for multiple sidebars
- introduce `/tools/tools.json` manifest listing available tools

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7c745cf08333a53c559b7342549f