### PR TITLE
feat: populate sidebar with full tool list on all pages

### DIFF
--- a/layout.js
+++ b/layout.js
@@ -5,6 +5,48 @@ document.addEventListener('DOMContentLoaded', () => {
   const sidebarOverlay = document.getElementById('sidebar-overlay');
   const toolSearch = document.getElementById('tool-search');
   const toolList = document.getElementById('tool-list');
+  const slug = document.body && document.body.dataset.slug;
+
+  const tools = [
+    { slug: 'image-converter', name: 'Image Converter' },
+    { slug: 'background-remover', name: 'Background Remover' },
+    { slug: 'google-ads-rsa-preview', name: 'Google Ads RSA Preview' },
+    { slug: 'campaign-structure', name: 'Campaign Structure' },
+    { slug: 'bulk-match-editor', name: 'Bulk Match Type Editor' },
+    { slug: 'json-formatter', name: 'JSON Formatter' },
+    { slug: 'color-palette', name: 'Colour Palette Extractor' },
+    { slug: 'pdf-merger', name: 'PDF Merger' },
+    { slug: 'utm-builder', name: 'UTM Builder' },
+    { slug: 'qr-generator', name: 'QR Code Generator' },
+    { slug: 'pdf-ocr', name: 'PDF OCR' },
+    { slug: 'uuid-generator', name: 'UUID Generator' },
+    { slug: 'timestamp-converter', name: 'Timestamp Converter' },
+    { slug: 'meta-tag-generator', name: 'Meta Tag Generator' },
+    { slug: 'robots-txt', name: 'Robots.txt Tool' },
+    { slug: 'text-case-converter', name: 'Text Case Converter' },
+    { slug: 'layout-tool', name: 'Layout Generator' }
+  ];
+
+  if (toolList) {
+    const basePath = slug ? '../' : 'tools/';
+    toolList.innerHTML = '';
+    tools.forEach(tool => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = `${basePath}${tool.slug}/index.html`;
+      a.textContent = tool.name;
+      a.className = 'text-[var(--foreground)] hover:text-[var(--primary)]';
+      li.appendChild(a);
+      toolList.appendChild(li);
+    });
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = '#';
+    a.textContent = 'More coming soon';
+    a.className = 'text-[var(--foreground)] hover:text-[var(--primary)]';
+    li.appendChild(a);
+    toolList.appendChild(li);
+  }
   // Sidebar remains overlayed across breakpoints so no main content offset is
   // needed.
 
@@ -51,7 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const slug = document.body && document.body.dataset.slug;
   if (slug) {
     const key = `visits_${slug}`;
     const count = parseInt(localStorage.getItem(key) || '0', 10) + 1;


### PR DESCRIPTION
## Summary
- Dynamically build sidebar tool list in `layout.js` from a single array of tools
- Compute correct relative links so every page displays the full tool list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d859f77448333a2bfbbe968927ec5