### PR TITLE
Refactor notifications to sanitize user messages

### DIFF
--- a/__tests__/notification-sanitization.test.js
+++ b/__tests__/notification-sanitization.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+global.window = dom.window;
+global.document = dom.window.document;
+global.localStorage = dom.window.localStorage;
+
+function loadUtils() {
+  const code = fs.readFileSync(path.resolve(__dirname, '../utils.js'), 'utf8');
+  const sanitized = code.replace(/export\s+/g, '');
+  const sandbox = {
+    window: window,
+    document: window.document,
+    console,
+    localStorage: window.localStorage,
+    setTimeout,
+    clearTimeout,
+  };
+  vm.createContext(sandbox);
+  new vm.Script(sanitized, { filename: 'utils.js' }).runInContext(sandbox);
+  return sandbox;
+}
+
+describe('notification utilities', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('showNotification renders message text safely', () => {
+    jest.useFakeTimers();
+    const { showNotification } = loadUtils();
+    const msg = '<b>alert</b>';
+    showNotification(msg, 'info');
+    const msgSpan = document.querySelector('#notification-container .notification div span:last-child');
+    expect(msgSpan.textContent).toBe(msg);
+    expect(msgSpan.querySelector('b')).toBeNull();
+    jest.runAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('showError renders filename and error text safely', () => {
+    const { showError } = loadUtils();
+    document.body.innerHTML = '<table><tbody id="preview-tbody"></tbody></table>';
+    const file = '<img src=x>';
+    const err = { message: '<script>alert(1)</script>' };
+    showError(0, file, err);
+    const row = document.querySelector('#preview-tbody tr.error-row');
+    expect(row.textContent).toContain(file);
+    expect(row.textContent).toContain(err.message);
+    expect(row.querySelector('img')).toBeNull();
+    expect(row.querySelector('script')).toBeNull();
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -14,7 +14,7 @@ export function showNotification(message, type = 'info') {
     notifContainer.style.maxWidth = '300px';
     document.body.appendChild(notifContainer);
   }
-  
+
   // Create notification element
   const notif = document.createElement('div');
   notif.className = 'notification';
@@ -29,21 +29,36 @@ export function showNotification(message, type = 'info') {
   notif.style.display = 'flex';
   notif.style.alignItems = 'center';
   notif.style.justifyContent = 'space-between';
-  
+
   // Add icon based on type
   const icon = type === 'error' ? '❌' : type === 'success' ? '✅' : 'ℹ️';
-  
-  // Add content
-  notif.innerHTML = `
-    <div style="display:flex;align-items:center;">
-      <span style="margin-right:8px;font-size:16px;">${icon}</span>
-      <span>${message}</span>
-    </div>
-    <button style="background:none;border:none;color:#cde5da;cursor:pointer;font-size:16px;margin-left:10px;">×</button>
-  `;
-  
+
+  // Build content elements
+  const content = document.createElement('div');
+  content.style.display = 'flex';
+  content.style.alignItems = 'center';
+
+  const iconSpan = document.createElement('span');
+  iconSpan.style.marginRight = '8px';
+  iconSpan.style.fontSize = '16px';
+  iconSpan.textContent = icon;
+
+  const messageSpan = document.createElement('span');
+  messageSpan.textContent = message;
+
+  content.appendChild(iconSpan);
+  content.appendChild(messageSpan);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.style.background = 'none';
+  closeBtn.style.border = 'none';
+  closeBtn.style.color = '#cde5da';
+  closeBtn.style.cursor = 'pointer';
+  closeBtn.style.fontSize = '16px';
+  closeBtn.style.marginLeft = '10px';
+  closeBtn.textContent = '×';
+
   // Add close button functionality
-  const closeBtn = notif.querySelector('button');
   closeBtn.addEventListener('click', () => {
     notif.style.opacity = '0';
     setTimeout(() => {
@@ -52,17 +67,20 @@ export function showNotification(message, type = 'info') {
       }
     }, 300);
   });
-  
+
+  notif.appendChild(content);
+  notif.appendChild(closeBtn);
+
   // Add to container
   notifContainer.appendChild(notif);
-  
+
   // Add animation
   notif.style.transition = 'opacity 0.3s ease';
   notif.style.opacity = '0';
   setTimeout(() => {
     notif.style.opacity = '1';
   }, 10);
-  
+
   // Auto-remove after 5 seconds
   setTimeout(() => {
     if (notif.parentNode) {
@@ -80,11 +98,22 @@ export function showNotification(message, type = 'info') {
 export function showError(index, filename, err) {
   const previewTbody = document.getElementById('preview-tbody');
   if (!previewTbody) return;
-  
+
   const tr = document.createElement('tr');
   tr.classList.add('error-row');
-  tr.innerHTML = `
-    <td colspan="7" class="py-2 px-4 text-left break-words">❌ <strong>${filename}</strong> – ${err && err.message ? err.message : err}</td>`;
+
+  const td = document.createElement('td');
+  td.colSpan = 7;
+  td.className = 'py-2 px-4 text-left break-words';
+
+  const strong = document.createElement('strong');
+  strong.textContent = filename;
+
+  td.appendChild(document.createTextNode('❌ '));
+  td.appendChild(strong);
+  td.appendChild(document.createTextNode(' – ' + (err && err.message ? err.message : err)));
+
+  tr.appendChild(td);
   previewTbody.appendChild(tr);
 }
 


### PR DESCRIPTION
## Summary
- Build notification and error elements with `createElement` and `textContent` instead of `innerHTML`
- Sanitize user-controlled values in notifications and error table rows
- Add tests ensuring HTML tags in inputs render as plain text

## Testing
- `npx jest __tests__/notification-sanitization.test.js`
- `npm test` *(fails: auth-redirect.test.js, unified-navigation.test.js, unified-navigation-enhanced.test.js, auth-state-sync.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6896864197c883338ab58f02a4f1e0d3