### PR TITLE
Refactor toast notifications to escape HTML and bind actions safely

### DIFF
--- a/__tests__/error-handler.test.js
+++ b/__tests__/error-handler.test.js
@@ -1,0 +1,51 @@
+const { JSDOM } = require('jsdom');
+
+describe('ErrorHandler toast security', () => {
+  let handler;
+  let dom;
+  let ErrorHandler;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    window.requestAnimationFrame = cb => cb();
+    global.requestAnimationFrame = window.requestAnimationFrame;
+    jest.resetModules();
+    ErrorHandler = require('../js/error-handler.js');
+    handler = new ErrorHandler();
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  test('escapes HTML in messages', () => {
+    const html = '<img src=x onerror="window.injected=true">';
+    const toast = handler.showToast('Title', html);
+    const messageEl = toast.querySelector('.toast-message');
+
+    expect(messageEl.innerHTML).toBe('&lt;img src=x onerror="window.injected=true"&gt;');
+    expect(window.injected).toBeUndefined();
+  });
+
+  test('actions execute only via bound handlers', () => {
+    let executed = false;
+    const toast = handler.showToast('Title', 'Message', 'info', {
+      actions: [
+        { label: '<img src=x onerror="window.injected=true">', action: () => { executed = true; } }
+      ]
+    });
+
+    const btn = toast.querySelector('.toast-actions button');
+    expect(btn).not.toBeNull();
+    expect(btn.innerHTML).toBe('&lt;img src=x onerror="window.injected=true"&gt;');
+    expect(window.injected).toBeUndefined();
+    expect(executed).toBe(false);
+
+    btn.click();
+
+    expect(executed).toBe(true);
+    expect(window.injected).toBeUndefined();
+  });
+});

--- a/js/error-handler.js
+++ b/js/error-handler.js
@@ -538,7 +538,7 @@ class ErrorHandler {
 
     const toast = document.createElement('div');
     toast.className = `toast ${type}`;
-    
+
     const icons = {
       success: '✓',
       error: '✕',
@@ -546,21 +546,64 @@ class ErrorHandler {
       info: 'ℹ'
     };
 
-    toast.innerHTML = `
-      <div class="toast-icon">${icons[type] || 'ℹ'}</div>
-      <div class="toast-content">
-        <div class="toast-title">${title}</div>
-        <div class="toast-message">${message}</div>
-        ${options.actions ? `
-          <div class="toast-actions">
-            ${options.actions.map(action => 
-              `<button class="toast-btn toast-btn-primary" onclick="this.closest('.toast').remove(); (${action.action.toString()})()">${action.label}</button>`
-            ).join('')}
-          </div>
-        ` : ''}
-      </div>
-      <button class="toast-close" onclick="this.closest('.toast').remove()">×</button>
-    `;
+    // Icon element
+    const iconEl = document.createElement('div');
+    iconEl.className = 'toast-icon';
+    iconEl.textContent = icons[type] || 'ℹ';
+
+    // Content wrapper
+    const contentEl = document.createElement('div');
+    contentEl.className = 'toast-content';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'toast-title';
+    titleEl.textContent = title;
+
+    const messageEl = document.createElement('div');
+    messageEl.className = 'toast-message';
+    messageEl.textContent = message;
+
+    contentEl.appendChild(titleEl);
+    contentEl.appendChild(messageEl);
+
+    if (Array.isArray(options.actions) && options.actions.length > 0) {
+      const actionsEl = document.createElement('div');
+      actionsEl.className = 'toast-actions';
+
+      options.actions.forEach(actionObj => {
+        if (!actionObj || typeof actionObj.action !== 'function') return;
+
+        const btn = document.createElement('button');
+        btn.className = 'toast-btn toast-btn-primary';
+
+        const label = typeof actionObj.label === 'string' ? actionObj.label : '';
+        btn.textContent = label;
+
+        btn.addEventListener('click', () => {
+          this.removeToast(toast);
+          try {
+            actionObj.action();
+          } catch (err) {
+            console.error('Toast action error:', err);
+          }
+        });
+
+        actionsEl.appendChild(btn);
+      });
+
+      if (actionsEl.childNodes.length > 0) {
+        contentEl.appendChild(actionsEl);
+      }
+    }
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'toast-close';
+    closeBtn.textContent = '×';
+    closeBtn.addEventListener('click', () => this.removeToast(toast));
+
+    toast.appendChild(iconEl);
+    toast.appendChild(contentEl);
+    toast.appendChild(closeBtn);
 
     container.appendChild(toast);
 


### PR DESCRIPTION
## Summary
- Build toast notifications with DOM APIs and escape all text to prevent injection
- Replace inline handlers with closure-based event listeners and validate action labels
- Add tests ensuring messages are escaped and actions execute only via bound handlers

## Testing
- `npm test` *(fails: AuthManager Redirect Functionality, UnifiedNavigation Path Resolution, Enhanced UnifiedNavigation with PathResolver, Authentication State Synchronization)*

------
https://chatgpt.com/codex/tasks/task_e_68968649a8788333a06f3f08435c5f46