### PR TITLE
Sanitize layout tool debug logging

### DIFF
--- a/tools/layout-tool/debug.html
+++ b/tools/layout-tool/debug.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -22,12 +23,18 @@
     function log(message, type = 'info') {
       const div = document.createElement('div');
       div.className = type;
-      div.innerHTML = message;
+
+      if (message instanceof Node) {
+        div.appendChild(message);
+      } else {
+        div.textContent = String(message);
+      }
+
       output.appendChild(div);
     }
     
     async function runDiagnostics() {
-      log('<h2>Running Diagnostics...</h2>');
+      log('Running Diagnostics...');
       
       // Test 1: Check if modules can be imported
       try {
@@ -41,7 +48,7 @@
         log(`✓ Loaded ${presets.length} presets successfully`, 'success');
         
         // Test 3: Show preset details
-        log('<h3>Preset Details:</h3>');
+        log('Preset Details:');
         const categories = {};
         presets.forEach(preset => {
           if (!categories[preset.category]) categories[preset.category] = [];
@@ -49,15 +56,17 @@
         });
         
         Object.entries(categories).forEach(([category, presets]) => {
-          log(`<strong>${category}:</strong> ${presets.length} presets`);
+          log(`${category}: ${presets.length} presets`);
           presets.forEach(preset => {
-            log(`&nbsp;&nbsp;- ${preset.name} (${preset.width || preset.width_mm}×${preset.height || preset.height_mm})`);
+            log(`- ${preset.name} (${preset.width || preset.width_mm}×${preset.height || preset.height_mm})`);
           });
         });
         
       } catch (error) {
         log(`✗ Error loading presets: ${error.message}`, 'error');
-        log(`<pre>${error.stack}</pre>`, 'error');
+        const stack = document.createElement('pre');
+        stack.textContent = error.stack;
+        log(stack, 'error');
       }
       
       // Test 4: Check if other modules load
@@ -84,7 +93,11 @@
       }
     }
     
-    runDiagnostics();
+    if (['localhost', '127.0.0.1'].includes(location.hostname)) {
+      runDiagnostics();
+    } else {
+      document.body.textContent = 'Debug page disabled in production.';
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent HTML injection in layout-tool debug output by using text nodes
- sanitize diagnostic messages and handle stack traces safely
- disable debug page outside localhost

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 2 passed, 6 total)*

------
https://chatgpt.com/codex/tasks/task_e_6896866535008333b7aa305b2c258a65