### PR TITLE
Load Supabase runtime config before client init

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ To enable enhanced features with user accounts:
 3. Configure Google OAuth in your Supabase dashboard
 4. Ensure your `users` table includes a `full_name` column
 
+> **Deployment Note:** Run `npm run build:config` before deploying to generate `js/supabase-config.js` from your current `SUPABASE_URL` and `SUPABASE_ANON_KEY` values.
+
 ### Analytics (Optional)
 The site includes Google Tag Manager integration (container `GTM-NFJTSQ3N`) for centralized analytics configuration.
 

--- a/auth.html
+++ b/auth.html
@@ -137,6 +137,7 @@
     <!-- Load Supabase and dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="styles/theme.js"></script>

--- a/js/universal-tool-template.js
+++ b/js/universal-tool-template.js
@@ -100,6 +100,7 @@ INTEGRATION CHECKLIST:
    <!-- Core Dependencies -->
    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
    <script src="../../js/config.js"></script>
+   <script src="../../js/supabase-config.js"></script>
    <script src="../../js/supabase-client.js"></script>
    <script src="../../js/auth-manager.js"></script>
    <script src="../../js/quota-manager.js"></script>

--- a/tools/background-remover/index.html
+++ b/tools/background-remover/index.html
@@ -14,6 +14,8 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/bulk-match-editor/index.html
+++ b/tools/bulk-match-editor/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/campaign-structure/index.html
+++ b/tools/campaign-structure/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/color-palette/index.html
+++ b/tools/color-palette/index.html
@@ -15,6 +15,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/google-ads-rsa-preview/index.html
+++ b/tools/google-ads-rsa-preview/index.html
@@ -32,6 +32,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/image-converter/index.html
+++ b/tools/image-converter/index.html
@@ -25,6 +25,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/json-formatter/index.html
+++ b/tools/json-formatter/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/layout-tool/index.html
+++ b/tools/layout-tool/index.html
@@ -16,6 +16,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/meta-tag-generator/index.html
+++ b/tools/meta-tag-generator/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/pdf-merger/index.html
+++ b/tools/pdf-merger/index.html
@@ -19,6 +19,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/pdf-ocr/index.html
+++ b/tools/pdf-ocr/index.html
@@ -16,6 +16,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/qr-generator/index.html
+++ b/tools/qr-generator/index.html
@@ -15,6 +15,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/request-tool/index.html
+++ b/tools/request-tool/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/robots-txt/index.html
+++ b/tools/robots-txt/index.html
@@ -15,6 +15,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/text-case-converter/index.html
+++ b/tools/text-case-converter/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/timestamp-converter/index.html
+++ b/tools/timestamp-converter/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/utm-builder/index.html
+++ b/tools/utm-builder/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>

--- a/tools/uuid-generator/index.html
+++ b/tools/uuid-generator/index.html
@@ -14,6 +14,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
+  <script src="../../js/supabase-config.js"></script>
   <script src="../../js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>


### PR DESCRIPTION
## Summary
- Read SUPABASE_URL and SUPABASE_ANON_KEY from env via `generate-supabase-config.js`
- Load generated `supabase-config.js` before `supabase-client.js` in auth and all tool pages
- Document running `npm run build:config` prior to deployment

## Testing
- `npm test` *(fails: Auth redirect and navigation tests)*
- `SUPABASE_URL="https://example.supabase.co" SUPABASE_ANON_KEY="anon_key" npm run build:config`

------
https://chatgpt.com/codex/tasks/task_e_68968d85b5c48333818e4e78a79f7bc7