### PR TITLE
Load Supabase runtime config before client scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules/
 
 # Environment and generated config
 .env.local
+# Generated Supabase runtime config
 js/supabase-config.js

--- a/analytics.html
+++ b/analytics.html
@@ -163,6 +163,7 @@
     <!-- Load dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/analytics-manager.js"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -613,6 +613,7 @@
     <!-- Load dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>

--- a/files.html
+++ b/files.html
@@ -519,6 +519,7 @@
     <!-- Load dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <!-- Supabase and Authentication -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="js/config.js"></script>
+  <script src="js/supabase-config.js"></script>
   <script src="js/supabase-client.js"></script>
   <script src="js/auth-manager.js"></script>
   <script src="js/profile-manager.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -508,6 +508,7 @@
     <!-- Core Dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/error-handler.js"></script>

--- a/pricing.html
+++ b/pricing.html
@@ -489,6 +489,7 @@
     <!-- Load dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>

--- a/profile.html
+++ b/profile.html
@@ -486,6 +486,7 @@
     <!-- Load dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>

--- a/reset-password.html
+++ b/reset-password.html
@@ -241,6 +241,7 @@
     <!-- Load Supabase and dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
 

--- a/test-auth-redirect-integration.html
+++ b/test-auth-redirect-integration.html
@@ -44,6 +44,7 @@
     <!-- Core Dependencies -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
+    <script src="js/supabase-config.js"></script>
     <script src="js/supabase-client.js"></script>
     <script src="js/path-resolver.js"></script>
     <script src="js/auth-manager.js"></script>

--- a/test-navigation-duplication.html
+++ b/test-navigation-duplication.html
@@ -11,6 +11,7 @@
   <!-- Core Dependencies -->
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="js/config.js"></script>
+  <script src="js/supabase-config.js"></script>
   <script src="js/supabase-client.js"></script>
   <script src="js/path-resolver.js"></script>
   <script src="js/auth-manager.js"></script>


### PR DESCRIPTION
## Summary
- ignore generated Supabase config
- load `js/supabase-config.js` before `supabase-client.js` on authenticated pages

## Testing
- `node scripts/generate-supabase-config.js`
- `npm test` *(fails: AuthManager Redirect Functionality, Enhanced UnifiedNavigation, AuthManager Redirect Functionality, Authentication State Synchronization)*

------
https://chatgpt.com/codex/tasks/task_e_6896aeefdedc8333aa3befea07d0248d