### PR TITLE
chore(config): add public config build step, Supabase client, Stripe serverless functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules/
 .vscode/
 
 # Environment and generated config
+.env
 .env.local
 # Generated Supabase runtime config
 js/supabase-config.js
+js/public-config.js

--- a/analytics.html
+++ b/analytics.html
@@ -161,10 +161,9 @@
     </div>
 
     <!-- Load dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/analytics-manager.js"></script>
     <script src="js/auth-guards.js"></script>

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -1,0 +1,25 @@
+// api/checkout.js
+const Stripe = require('stripe');
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  try {
+    const { amount, currency = 'usd', metadata } = JSON.parse(req.body || '{}');
+    if (!amount || typeof amount !== 'number') return res.status(400).json({ error: 'amount required' });
+
+    const pi = await stripe.paymentIntents.create({
+      amount,
+      currency,
+      automatic_payment_methods: { enabled: true },
+      metadata
+    });
+
+    res.status(200).json({ clientSecret: pi.client_secret });
+  } catch (err) {
+    console.error('[checkout]', err);
+    res.status(500).json({ error: 'server_error' });
+  }
+};
+

--- a/api/env-check.js
+++ b/api/env-check.js
@@ -1,0 +1,11 @@
+// api/env-check.js
+module.exports = async (req, res) => {
+  res.json({
+    HAS_SUPABASE_URL: Boolean(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL),
+    HAS_SUPABASE_ANON_KEY: Boolean(process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
+    HAS_STRIPE_PUBLISHABLE: Boolean(process.env.STRIPE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY),
+    HAS_STRIPE_SECRET: Boolean(process.env.STRIPE_SECRET_KEY),
+    HAS_WEBHOOK_SECRET: Boolean(process.env.STRIPE_WEBHOOK_SECRET)
+  });
+};
+

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -1,0 +1,24 @@
+// api/stripe-webhook.js
+const Stripe = require('stripe');
+const getRawBody = require('raw-body');
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  let event;
+  try {
+    const sig = req.headers['stripe-signature'];
+    const raw = (await getRawBody(req)).toString('utf8');
+    event = stripe.webhooks.constructEvent(raw, sig, process.env.STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    console.error('[webhook verify]', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  // TODO: handle event types
+
+  res.status(200).end();
+};
+

--- a/auth.html
+++ b/auth.html
@@ -135,10 +135,9 @@
     </div>
 
     <!-- Load Supabase and dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+<script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/auth-state-sync.js"></script>
     <script src="styles/theme.js"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -611,10 +611,9 @@
     </div>
 
     <!-- Load dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>
     <script src="js/quota-manager.js"></script>

--- a/files.html
+++ b/files.html
@@ -517,10 +517,9 @@
     </div>
 
     <!-- Load dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>
     <script src="js/quota-manager.js"></script>

--- a/index.html
+++ b/index.html
@@ -18,10 +18,9 @@
   <script src="home.js"></script>
   
   <!-- Supabase and Authentication -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="js/config.js"></script>
-  <script src="js/supabase-config.js"></script>
-  <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="js/auth-manager.js"></script>
   <script src="js/profile-manager.js"></script>
   <script src="js/quota-manager.js"></script>

--- a/js/auth-init.js
+++ b/js/auth-init.js
@@ -39,10 +39,7 @@
     
     // Load required scripts in sequence
     const scripts = [
-      'https://unpkg.com/@supabase/supabase-js@2',
-      `${basePath}js/supabase-config.js`,
       `${basePath}js/config.js`,
-      `${basePath}js/supabase-client.js`,
       `${basePath}js/auth-manager.js`,
       `${basePath}js/auth-modal.js`,
       `${basePath}js/auth-guards.js`,

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -1,100 +1,16 @@
-/**
- * Supabase Client Configuration
- * Initializes the Supabase client using runtime configuration
- */
+// js/supabase-client.js
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-// Import Supabase client from CDN (will be loaded in HTML)
-// This assumes the Supabase JS library is loaded via CDN in the HTML
-
-class SupabaseClient {
-  constructor() {
-    const config = window.SUPABASE_CONFIG || {};
-    this.supabaseUrl = config.SUPABASE_URL;
-    this.supabaseAnonKey = config.SUPABASE_ANON_KEY;
-
-    if (!this.supabaseUrl || !this.supabaseAnonKey) {
-      console.error('Supabase configuration missing: generate js/supabase-config.js.');
-      return;
-    }
-
-    // Initialize Supabase client
-    this.client = window.supabase.createClient(this.supabaseUrl, this.supabaseAnonKey);
-
-    // Initialize auth state listener
-    this.initAuthListener();
-  }
-
-  /**
-   * Initialize authentication state listener
-   */
-  initAuthListener() {
-    this.client.auth.onAuthStateChange((event, session) => {
-      console.log('Auth state changed:', event, session);
-      
-      // Dispatch custom event for other components to listen to
-      window.dispatchEvent(new CustomEvent('supabase-auth-change', {
-        detail: { event, session }
-      }));
-      
-      // Update UI based on auth state
-      this.updateAuthUI(session);
-    });
-  }
-
-  /**
-   * Update UI elements based on authentication state
-   */
-  updateAuthUI(session) {
-    const authElements = document.querySelectorAll('[data-auth-required]');
-    const guestElements = document.querySelectorAll('[data-guest-only]');
-    
-    if (session) {
-      // User is logged in
-      authElements.forEach(el => el.style.display = 'block');
-      guestElements.forEach(el => el.style.display = 'none');
-    } else {
-      // User is not logged in
-      authElements.forEach(el => el.style.display = 'none');
-      guestElements.forEach(el => el.style.display = 'block');
-    }
-  }
-
-  /**
-   * Get the current Supabase client instance
-   */
-  getClient() {
-    return this.client;
-  }
-
-  /**
-   * Get the current user session
-   */
-  async getCurrentSession() {
-    const { data: { session }, error } = await this.client.auth.getSession();
-    if (error) {
-      console.error('Error getting session:', error);
-      return null;
-    }
-    return session;
-  }
-
-  /**
-   * Get the current user
-   */
-  async getCurrentUser() {
-    const { data: { user }, error } = await this.client.auth.getUser();
-    if (error) {
-      console.error('Error getting user:', error);
-      return null;
-    }
-    return user;
-  }
+if (!window.PUBLIC_ENV) {
+  throw new Error('PUBLIC_ENV not loaded. Include /js/public-config.js before this script.');
 }
 
-// Create global instance
-window.supabaseClient = new SupabaseClient();
+const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.PUBLIC_ENV;
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true }
+});
 
-// Export for module usage
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = SupabaseClient;
-}
+// expose for legacy scripts
+window.supabase = supabase;
+window.supabaseClient = { getClient: () => supabase };
+

--- a/layout.html
+++ b/layout.html
@@ -506,10 +506,9 @@
     </footer>
 
     <!-- Core Dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/error-handler.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "background-remover.js",
   "scripts": {
     "test": "jest",
-    "build:config": "node scripts/generate-supabase-config.js"
+    "build:config": "node scripts/generate-supabase-config.js",
+    "generate:public-config": "node scripts/generate-public-config.js"
   },
   "keywords": [],
   "author": "",

--- a/pricing.html
+++ b/pricing.html
@@ -487,10 +487,9 @@
     </div>
 
     <!-- Load dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>
     <script src="js/quota-manager.js"></script>

--- a/profile.html
+++ b/profile.html
@@ -484,10 +484,9 @@
     </div>
 
     <!-- Load dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
     <script src="js/profile-manager.js"></script>
     <script src="js/auth-guards.js"></script>

--- a/reset-password.html
+++ b/reset-password.html
@@ -239,10 +239,9 @@
     </div>
 
     <!-- Load Supabase and dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/auth-manager.js"></script>
 
     <script>

--- a/scripts/generate-public-config.js
+++ b/scripts/generate-public-config.js
@@ -1,0 +1,25 @@
+// scripts/generate-public-config.js
+const fs = require('fs');
+const path = require('path');
+
+// Only PUBLIC values (safe for browser):
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const STRIPE_PUBLISHABLE_KEY = process.env.STRIPE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+
+for (const [k, v] of Object.entries({ SUPABASE_URL, SUPABASE_ANON_KEY })) {
+  if (!v) {
+    console.error(`[build] Missing ${k} in environment. Set it in Vercel.`);
+    process.exit(1);
+  }
+}
+
+fs.mkdirSync('js', { recursive: true });
+const out = `window.PUBLIC_ENV=${JSON.stringify({
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  STRIPE_PUBLISHABLE_KEY: STRIPE_PUBLISHABLE_KEY || null
+})};`;
+fs.writeFileSync(path.join('js', 'public-config.js'), out);
+console.log('[build] Wrote js/public-config.js');
+

--- a/test-auth-redirect-integration.html
+++ b/test-auth-redirect-integration.html
@@ -42,10 +42,9 @@
     <div id="test-results"></div>
     
     <!-- Core Dependencies -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
-    <script src="js/supabase-config.js"></script>
-    <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
     <script src="js/path-resolver.js"></script>
     <script src="js/auth-manager.js"></script>
     

--- a/test-navigation-duplication.html
+++ b/test-navigation-duplication.html
@@ -9,10 +9,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="js/config.js"></script>
-  <script src="js/supabase-config.js"></script>
-  <script src="js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="js/path-resolver.js"></script>
   <script src="js/auth-manager.js"></script>
   <script src="js/unified-navigation.js"></script>

--- a/test-supabase.html
+++ b/test-supabase.html
@@ -141,9 +141,13 @@
         <pre id="functionsResults"></pre>
     </div>
 
-    <!-- Load Supabase from CDN -->
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
-    
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
+    <script type="module">
+        import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+        window.createSupabaseClient = (url, key) => createClient(url, key);
+    </script>
+
     <script>
         let supabase = null;
         let currentUser = null;
@@ -153,14 +157,14 @@
         function initializeSupabase() {
             const url = document.getElementById('supabaseUrl').value;
             const key = document.getElementById('supabaseKey').value;
-            
+
             if (!url || !key) {
                 showStatus('initStatus', 'Please enter both URL and key', 'error');
                 return;
             }
 
             try {
-                supabase = window.supabase.createClient(url, key);
+                supabase = window.createSupabaseClient(url, key);
                 showStatus('initStatus', 'Supabase initialized successfully!', 'success');
                 
                 // Set up auth listener

--- a/tools/background-remover/index.html
+++ b/tools/background-remover/index.html
@@ -12,11 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/bulk-match-editor/index.html
+++ b/tools/bulk-match-editor/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/campaign-structure/index.html
+++ b/tools/campaign-structure/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/color-palette/index.html
+++ b/tools/color-palette/index.html
@@ -13,10 +13,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/color-thief/2.3.2/color-thief.umd.js"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/google-ads-rsa-preview/index.html
+++ b/tools/google-ads-rsa-preview/index.html
@@ -30,10 +30,9 @@
   <script type="module" src="../../layout.js"></script>
 
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/image-converter/index.html
+++ b/tools/image-converter/index.html
@@ -23,10 +23,9 @@
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/json-formatter/index.html
+++ b/tools/json-formatter/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/layout-tool/index.html
+++ b/tools/layout-tool/index.html
@@ -14,10 +14,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/meta-tag-generator/index.html
+++ b/tools/meta-tag-generator/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/pdf-merger/index.html
+++ b/tools/pdf-merger/index.html
@@ -17,10 +17,9 @@
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/pdf-ocr/index.html
+++ b/tools/pdf-ocr/index.html
@@ -14,10 +14,9 @@
   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/qr-generator/index.html
+++ b/tools/qr-generator/index.html
@@ -13,10 +13,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/request-tool/index.html
+++ b/tools/request-tool/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/robots-txt/index.html
+++ b/tools/robots-txt/index.html
@@ -13,10 +13,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.js"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/text-case-converter/index.html
+++ b/tools/text-case-converter/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/timestamp-converter/index.html
+++ b/tools/timestamp-converter/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/utm-builder/index.html
+++ b/tools/utm-builder/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>

--- a/tools/uuid-generator/index.html
+++ b/tools/uuid-generator/index.html
@@ -12,10 +12,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- Font Awesome for icons -->
   <!-- Core Dependencies -->
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script src="../../js/config.js"></script>
-  <script src="../../js/supabase-config.js"></script>
-  <script src="../../js/supabase-client.js"></script>
+    <script src="/js/public-config.js"></script>
+    <script type="module" src="/js/supabase-client.js"></script>
   <script src="../../js/path-resolver.js"></script>
   <script src="../../js/auth-manager.js"></script>
   <script src="../../js/auth-state-sync.js"></script>


### PR DESCRIPTION
## Summary
- generate public config at build time for browser-safe env vars
- replace legacy Supabase client with PUBLIC_ENV based module
- add Stripe checkout, webhook, and env check serverless functions

## Testing
- `npm test` *(fails: auth-redirect, unified-navigation, auth-state-sync suites)*

------
https://chatgpt.com/codex/tasks/task_e_689684be2e048333a624a26fa763de3a