### PR TITLE
Refine image converter controls and quota messaging

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1055,3 +1055,29 @@ nav .flex.items-center {
 .dropdown-content {
   z-index: 9999;
 }
+
+/* Responsive control panel */
+#controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+#controls .control-item {
+  flex: 1 1 30%;
+}
+
+@media (max-width: 992px) {
+  #controls .control-item {
+    flex: 1 1 45%;
+  }
+}
+
+@media (max-width: 576px) {
+  #controls {
+    flex-direction: column;
+  }
+  #controls .control-item {
+    flex: 1 1 100%;
+  }
+}

--- a/tools/image-converter/auth-simple.js
+++ b/tools/image-converter/auth-simple.js
@@ -17,6 +17,7 @@ class ImageConverterAuth {
       // Load usage from localStorage for anonymous users
       this.loadLocalUsage();
       this.isInitialized = true;
+      this.updateUI();
       console.log('✅ Image Converter Auth initialized');
     } catch (error) {
       console.error('❌ Auth initialization failed:', error);
@@ -53,25 +54,10 @@ class ImageConverterAuth {
   }
 
   updateUI() {
-    const remaining = this.getRemainingConversions();
-    const usageElement = document.getElementById('usage-counter');
-    
-    if (usageElement) {
-      if (remaining > 0) {
-        usageElement.innerHTML = `
-          <div class="text-sm text-muted-foreground">
-            <i class="fas fa-image mr-1"></i>
-            ${remaining} free conversions remaining
-          </div>
-        `;
-      } else {
-        usageElement.innerHTML = `
-          <div class="text-sm text-destructive">
-            <i class="fas fa-exclamation-triangle mr-1"></i>
-            Free limit reached. <a href="#upgrade" class="text-primary underline">Upgrade for unlimited conversions</a>
-          </div>
-        `;
-      }
+    const quotaElement = document.getElementById('quota-status');
+    if (quotaElement) {
+      const remaining = this.getRemainingConversions();
+      quotaElement.textContent = `${remaining} free conversions remaining. Quota resets every 24 hours.`;
     }
   }
 

--- a/tools/image-converter/index.html
+++ b/tools/image-converter/index.html
@@ -119,54 +119,47 @@
     </aside>
     <main id="main-content" class="flex-grow p-4">
       <!-- Main Content Area -->
-  <h1 class="text-3xl font-bold text-center my-8" style="color: var(--foreground);">Image Conversion Tool</h1>
-  <section class="max-w-3xl mx-auto mb-8 space-y-2">
-    <p class="text-foreground">Convert images right in your browser without installing software. Resize, set a target output size and export to formats like WebP, JPEG or AVIF.</p>
-  </section>
-    <main id="main-content" class="flex-grow">
-      <!-- Main Content Area -->
-    <h1 class="text-3xl font-bold text-center my-8" style="color: var(--foreground);">Image Conversion Tool</h1>
-    <div id="controls" class="flex flex-col sm:flex-row flex-wrap justify-center gap-4 mb-8">
+      <h1 class="text-3xl font-bold text-center my-8" style="color: var(--foreground);">Image Conversion Tool</h1>
+      <section class="max-w-3xl mx-auto mb-8 space-y-2">
+        <p class="text-foreground">Convert images right in your browser without installing software. Resize, set a target output size and export to formats like WebP, JPEG or AVIF.</p>
+      </section>
 
-      <div class="bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2 w-full sm:flex-1">
-        <label for="max-width" class="font-medium">Max Width:</label>
-        <input id="max-width" type="number" min="1" max="99999" value="99999" class="w-full sm:flex-1 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
-        <span class="text-gray-500">px</span>
-      </div>
-      <div class="bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2 w-full sm:flex-1">
-        <label for="max-height" class="font-medium">Max Height:</label>
-        <input id="max-height" type="number" min="1" max="99999" value="99999" class="w-full sm:flex-1 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
-        <span class="text-gray-500">px</span>
-      </div>
-      <div class="bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2 w-full sm:flex-1">
-        <label for="target-size" class="font-medium">Target Size:</label>
-        <input id="target-size" type="number" min="1" value="500" class="w-full sm:flex-1 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
-        <select id="size-unit" class="border rounded px-1 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 w-full sm:w-auto appearance-none bg-no-repeat bg-right pr-6" style="background-color:var(--background);color:var(--foreground);background-image:url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48cGF0aCBkPSJNMTkgOWwtNyA3LTctNyIvPjwvc3ZnPg==');background-size:1rem;background-position:right 0.5rem center;">
+      <div id="controls" class="control-panel mb-8">
+        <fieldset id="size-mode" class="control-item bg-white rounded shadow px-3 py-2 flex items-center gap-4 w-full">
+          <legend class="sr-only">Size mode</legend>
+          <label for="mode-dimensions" class="flex items-center gap-1">
+            <input type="radio" id="mode-dimensions" name="size-mode" value="dimensions" checked>
+            <span>Dimensions</span>
+          </label>
+          <label for="mode-filesize" class="flex items-center gap-1">
+            <input type="radio" id="mode-filesize" name="size-mode" value="filesize">
+            <span>File Size</span>
+          </label>
+        </fieldset>
 
-      <div class="bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2 w-full sm:w-auto">
-        <label for="max-width" class="font-medium">Max Width:</label>
-        <input id="max-width" type="number" min="1" max="99999" value="99999" class="w-full sm:w-20 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
-        <span class="text-gray-500">px</span>
-      </div>
-      <div class="bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2 w-full sm:w-auto">
-        <label for="max-height" class="font-medium">Max Height:</label>
-        <input id="max-height" type="number" min="1" max="99999" value="99999" class="w-full sm:w-20 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
-        <span class="text-gray-500">px</span>
-      </div>
-      <div class="bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2 w-full sm:w-auto">
-        <label for="target-size" class="font-medium">Target Size:</label>
-        <input id="target-size" type="number" min="1" value="500" class="w-full sm:w-24 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
-        <select id="size-unit" class="border rounded px-1 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 w-full sm:w-auto">
+        <div id="width-control" class="control-item bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2">
+          <label for="max-width" class="font-medium">Max Width:</label>
+          <input id="max-width" type="number" min="1" max="99999" value="99999" class="w-full sm:flex-1 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
+          <span class="text-gray-500">px</span>
+        </div>
 
-          <option value="KB">KB</option>
-          <option value="MB">MB</option>
-        </select>
+        <div id="height-control" class="control-item bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2">
+          <label for="max-height" class="font-medium">Max Height:</label>
+          <input id="max-height" type="number" min="1" max="99999" value="99999" class="w-full sm:flex-1 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" />
+          <span class="text-gray-500">px</span>
+        </div>
+
+        <div id="file-size-group" class="control-item bg-white rounded shadow px-3 py-2 flex flex-col sm:flex-row items-center gap-2 hidden">
+          <label for="target-size" class="font-medium">Target Size:</label>
+          <input id="target-size" type="number" min="1" value="500" class="w-full sm:flex-1 border rounded px-2 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300" disabled />
+          <select id="size-unit" class="border rounded px-1 py-1 text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 w-full sm:w-auto" disabled>
+            <option value="KB">KB</option>
+            <option value="MB">MB</option>
+          </select>
+        </div>
       </div>
-    </div>
     <div id="format-controls" class="flex flex-col sm:flex-row justify-center mb-4 items-center gap-2">
       <label for="output-format" class="font-medium mr-0 sm:mr-2">Output Format:</label>
-
-      <select id="output-format" class="border rounded px-2 py-1 w-full sm:w-auto appearance-none bg-no-repeat bg-right pr-8" style="background-color:var(--background);color:var(--foreground);border:1.5px solid var(--foreground);background-image:url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48cGF0aCBkPSJNMTkgOWwtNyA3LTctNyIvPjwvc3ZnPg==');background-size:1rem;background-position:right 0.5rem center;">
 
       <select id="output-format" class="border rounded px-2 py-1 w-full sm:w-auto" style="background-color:var(--background);color:var(--foreground);border:1.5px solid var(--foreground);">
 
@@ -185,12 +178,9 @@
     <div id="progress-bar-container" class="w-full max-w-2xl mx-auto mb-4">
       <div id="progress-bar"></div>
     </div>
-    <div id="quota-status" class="text-center text-base font-medium mb-2" style="color:hsl(39 100% 64%);"></div>
-    
-    <!-- Usage Counter -->
-    <div id="usage-counter" class="text-center mb-4"></div>
-    
-    <!-- Hidden legacy auth controls for backwards compatibility -->
+      <div id="quota-status" class="text-center text-base font-medium mb-2" style="color:hsl(39 100% 64%);"></div>
+
+      <!-- Hidden legacy auth controls for backwards compatibility -->
     <div id="auth-controls" class="text-center mb-4" style="display: none;">
       <input id="auth-email" type="email" placeholder="Email" class="border rounded px-2 py-1 mr-2" />
       <input id="auth-password" type="password" placeholder="Password" class="border rounded px-2 py-1 mr-2" />
@@ -210,7 +200,7 @@
       </div>
     </div>
     <!-- File Drop Area -->
-    <div id="drop-area" class="border-2 border-dashed border-blue-400 rounded-lg p-4 sm:p-8 text-center text-blue-500 mb-8 bg-white shadow hover:shadow-lg transition-shadow cursor-pointer max-w-2xl mx-auto px-4">
+      <div id="drop-area" role="button" tabindex="0" aria-label="Upload images by drag and drop or browse for files" class="border-2 border-dashed border-blue-400 rounded-lg p-4 sm:p-8 text-center text-blue-500 mb-8 bg-white shadow hover:shadow-lg transition-shadow cursor-pointer max-w-2xl mx-auto px-4">
       <p class="mb-4">Drag & drop your image files here</p>
       <p class="mb-4" style="color: var(--primary); font-size: 0.9rem;">Supports JPEG, PNG, WebP, GIF, AVIF, BMP, TIFF, ICO, HEIC/HEIF and RAW formats (CR2, NEF, ARW, etc)</p>
       <div style="display: flex; justify-content: center; gap: 20px; margin-bottom: 10px;">

--- a/utils.js
+++ b/utils.js
@@ -136,16 +136,21 @@ export function setQuotaInfo(quota) {
 }
 
 export function updateQuotaStatus() {
-  const quota = getQuotaInfo();
-  const left = Math.max(0, 100 - quota.used);
+  let left;
+  if (window.imageAuth && typeof window.imageAuth.getRemainingConversions === 'function') {
+    left = window.imageAuth.getRemainingConversions();
+  } else {
+    const quota = getQuotaInfo();
+    left = Math.max(0, 100 - quota.used);
+  }
+
   const quotaStatus = document.getElementById('quota-status');
   const upgradeBtn = document.getElementById('upgrade-btn');
-  
+
   if (quotaStatus) {
-    quotaStatus.textContent = `Free quota: ${left} of 100 images left (resets in ${Math.ceil((24*60*60*1000 - (Date.now() - quota.start))/3600000)}h)`;
+    quotaStatus.textContent = `${left} free conversions remaining. Quota resets every 24 hours.`;
   }
-  
-  // Show upgrade button if quota is low or zero
+
   if (upgradeBtn) {
     upgradeBtn.style.display = (left <= 2) ? 'inline-block' : 'none';
   }


### PR DESCRIPTION
## Summary
- Consolidate image conversion controls with a size-mode toggle and remove duplicate heading
- Display quota information in a single element that resets every 24 hours
- Improve control panel responsiveness and keyboard accessibility for the drop zone

## Testing
- `npm test` *(fails: TypeError: authManager.storeToolPageForRedirect is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689aebec01c08333a901048797745e5e